### PR TITLE
Pycsw

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ __pycache__/
 doc/mmd-specification.html
 doc/mmd-specification.pdf
 .coverage
+.cache
+.ipython

--- a/bin/sentinel1_mmd_to_csw_iso19139.py
+++ b/bin/sentinel1_mmd_to_csw_iso19139.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import lxml.etree as ET
 import xmltodict
@@ -44,7 +44,8 @@ def mmd2iso(mmd_file, xslt):
     xslt = ET.parse(xslt)
     transform = ET.XSLT(xslt)
     iso = transform(mmd)
-    return xmltodict.parse(iso)
+    #return xmltodict.parse(iso)
+    return iso
 
 
 def fixrecord(doc, pretty=False):
@@ -129,13 +130,18 @@ def writerecord(inputfile, xsl='../xslt/mmd-to-iso.xsl', outdir='/tmp'):
     pathlib.Path(outdir).mkdir(parents=True, exist_ok=True)
     iso_xml = mmd2iso(inputfile, xsl)
     outputfile = pathlib.PurePosixPath(outdir).joinpath(pathlib.PurePosixPath(inputfile).name)
-    with open(outputfile, 'w') as isofix:
-        isofix.write(fixrecord(iso_xml, pretty=True))
+    iso_xml.write_output(str(outputfile))
+    #with open(outputfile, 'w') as isofix:
+        #isofix.write(fixrecord(iso_xml, pretty=True))
+        #isofix.write(xmltodict.unparse(iso_xml, pretty=True))
+        #isofix.write(iso_xml)
 
 
 def main(metadata, outdir):
     xmlfiles = filelist(metadata)
-    y = parmap.map(writerecord, xmlfiles, outdir=outdir, pm_pbar=False)
+    #y = parmap.map(writerecord, xmlfiles, outdir=outdir, pm_pbar=False)
+    for e in xmlfiles:
+        writerecord(e, outdir=outdir)
 
 
 

--- a/xslt/mmd-to-iso.xsl
+++ b/xslt/mmd-to-iso.xsl
@@ -310,7 +310,10 @@
                 </xsl:element>
                 <xsl:element name="gmd:protocol">
                     <xsl:element name="gco:CharacterString">
-                        <xsl:value-of select="mmd:type" />
+                        <!--xsl:value-of select="mmd:type" / -->
+                        <xsl:variable name="mmd_da_type" select="normalize-space(./mmd:type)" />
+                        <xsl:variable name="mmd_da_mapping" select="document('')/*/mapping:data_access_type[@mmd=$mmd_da_type]/@iso" />
+                        <xsl:value-of select="$mmd_da_mapping" />
                     </xsl:element>
                 </xsl:element>            
                 <xsl:element name="gmd:name">
@@ -429,9 +432,8 @@
 
         <xsl:element name="gmd:status">
             <xsl:variable name="mmd_status" select="normalize-space(.)" />
-            <xsl:variable name="mmd_status_mapping" select="document('')/*/mapping:dataset_status[@mmd=$mmd_status]" />
+            <xsl:variable name="mmd_status_mapping" select="document('')/*/mapping:dataset_status[@mmd=$mmd_status]/@iso" />
             <xsl:value-of select="$mmd_status_mapping" />
-            <xsl:value-of select="$mmd_status_mapping/@iso" />                                
         </xsl:element>
 
     </xsl:template>
@@ -444,10 +446,18 @@
         </xsl:element>
     </xsl:template>
 
-   
+    <!-- Mappings for dataset_production_status -->
     <mapping:dataset_status iso="completed" mmd="Complete" />
     <mapping:dataset_status iso="obsolete" mmd="Obsolete" />
     <mapping:dataset_status iso="onGoing" mmd="In Work" />
     <mapping:dataset_status iso="planned" mmd="Planned" />    
+
+    <!-- Mappings for data_access type specification -->
+    <mapping:data_access_type iso="OGC:WMS" mmd="OGC WMS" />    
+    <mapping:data_access_type iso="OGC:WCS" mmd="OGC WCS" />    
+    <mapping:data_access_type iso="OGC:WFS" mmd="OGC WFS" />    
+    <mapping:data_access_type iso="WWW:DOWNLOAD-1.0-ftp–download" mmd="FTP" />  
+    <mapping:data_access_type iso="WWW:DOWNLOAD-1.0-http–download" mmd="HTTP" />
+    <mapping:data_access_type iso="WWW:LINK-1.0-http–opendap" mmd="OPeNDAP" />  
 
 </xsl:stylesheet>

--- a/xslt/mmd-to-iso.xsl
+++ b/xslt/mmd-to-iso.xsl
@@ -305,7 +305,23 @@
             <xsl:element name="gmd:CI_OnlineResource">
                 <xsl:element name="gmd:linkage">
                     <xsl:element name="gmd:URL">
-                        <xsl:value-of select="mmd:resource" />
+                        <xsl:variable name="myprot" select="normalize-space(./mmd:type)" />
+                        <xsl:choose>
+                            <xsl:when test="contains($myprot,'OGC WMS')">
+                                <xsl:variable name="myurl" select="normalize-space(./mmd:resource)" />
+                                <xsl:choose>
+                                    <xsl:when test="contains($myurl,'?SERVICE=WMS&amp;REQUEST=GetCapabilities')">
+                                        <xsl:value-of select="mmd:resource" />
+                                    </xsl:when>
+                                    <xsl:otherwise>
+                                        <xsl:value-of select="concat($myurl,'?SERVICE=WMS&amp;REQUEST=GetCapabilities')" />
+                                    </xsl:otherwise>
+                                </xsl:choose>
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <xsl:value-of select="mmd:resource" />
+                            </xsl:otherwise>
+                        </xsl:choose>
                     </xsl:element>
                 </xsl:element>
                 <xsl:element name="gmd:protocol">


### PR DESCRIPTION
Translations of protocol specifications for data_access are added, this link between MMD and pyCSW vocabulary. In addition checking of URLs for WMS is added. If the GetCapabilities request is missing, this is added. Currently this latter implementation is case sensitive, not sure if that is an issue. Please check if this works in the context of pyCSW integration. Further modifications to the ISO19115 translation is needed for various profiles including INSPIRE and WMO.