### PR TITLE
controlled vocabulary for keywords attribute

### DIFF
--- a/doc/ch01-introduction.adoc
+++ b/doc/ch01-introduction.adoc
@@ -23,10 +23,10 @@ Directory Interchange Format]
 7.  http://cfconventions.org/[Climate and Forecast Convention]…
 8.  http://wiki.esipfed.org/index.php?title=Category:Attribute_Conventions_Dataset_Discovery[Attribute Convention for Dataset Discovery]
 9.  ISO8601…
-10. [[anchor-2]]http://gcmdservices.gsfc.nasa.gov/static/kms/sciencekeywords/sciencekeywords.csv[GCMD Science Keywords]
+10. [[anchor-2]]https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/sciencekeywords/?format=csv[GCMD Science Keywords]
 11. [[anchor-3]]http://cfconventions.org/standard-names.html[Climate and
 Forecast Standard Names]
-12. [[anchor-4]]SeaDataNet
+12. [[anchor-4]]https://vocab.seadatanet.org/search[SeaDataNet]
 13. http://docs.opendap.org/index.php/Documentation[OPeNDAP]
 
 [[scope]]

--- a/doc/ch02-md-elements-keywords.adoc
+++ b/doc/ch02-md-elements-keywords.adoc
@@ -25,7 +25,7 @@ element has two child elements:
 * keyword: A single keyword describing the dataset. This can be hierarchically like GCMD using a separator.
 * separator: the character used as separator. This could be e.g. the GCMD ‘>’, but in XML this is encoded as ‘&gt;’. Other valid separators are: \| / -. 
 
-Additional controlled vocabularies maye be used, as WIGOS (https://codes.wmo.int/wmdr/) and SeaDataNet <<anchor-4, (see 12)>> etc. The primary usage for this element is to describe variables in the dataset, but it
+Additional controlled vocabularies may be used, as WIGOS (https://codes.wmo.int/wmdr/) and SeaDataNet <<anchor-4, (see 12)>> etc. The primary usage for this element is to describe variables in the dataset, but it
 could also be used to describe other features.
 
 |Example XML: a|

--- a/doc/ch02-md-elements-keywords.adoc
+++ b/doc/ch02-md-elements-keywords.adoc
@@ -7,7 +7,7 @@
 
 |Attributes a| 
 
-* vocabulary: The vocabulary where the keyword is fetched from. The vocabulary “none” is used if the keyword is not from a vocabulary. The recommended vocabulary to use is "GCMD", see <<variable-parameter-descriptions>> for further details. Other valid vocabularies are e.g. "WIGOS". Search services are currently based on GCMD Science keywords.
+* vocabulary: The vocabulary where the keyword is fetched from. The vocabulary “none” is used if the keyword is not from a vocabulary. The recommended vocabularies to use are listed in <<keywords-vocabulary>>, see also <<variable-parameter-descriptions>> for further details. Search services are currently based on GCMD Science keywords (GCMDSK).
 
 |Required |Yes
 
@@ -24,10 +24,8 @@ element has two child elements:
 * resource: URI to machine readable form of the vocabulary used.
 * keyword: A single keyword describing the dataset. This can be hierarchically like GCMD using a separator.
 * separator: the character used as separator. This could be e.g. the GCMD ‘>’, but in XML this is encoded as ‘&gt;’. Other valid separators are: \| / -. 
-Valid controlled vocabularies are GCMD Science Keywords
-link:#anchor-2[[10]], Climate and Forecast Standard Names
-link:#anchor-3[[11]], SeaDataNet link:#anchor-4[[12]] etc. The primary
-usage for this element is to describe variables in the dataset, but it
+
+Additional controlled vocabularies maye be used, as WIGOS (https://codes.wmo.int/wmdr/) and SeaDataNet <<anchor-4, (see 12)>> etc. The primary usage for this element is to describe variables in the dataset, but it
 could also be used to describe other features.
 
 |Example XML: a|
@@ -37,10 +35,10 @@ could also be used to describe other features.
      <keyword>Manual Generated Ice Edge</keyword>
 </keywords>
 
-<keywords vocabulary="GCMD">
-    <keyword>Earth Science - Climate Indicators - Teleconnections - North Atlantic Oscillation</keyword>
-    <resource>https://gcmdservices.gsfc.nasa.gov/static/kms/</resource>
-    <separator>-</separator>
+<keywords vocabulary="GCMDSK">
+    <keyword>Earth Science &gt; Climate Indicators &gt; Teleconnections &gt; North Atlantic Oscillation</keyword>
+    <resource>https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/sciencekeywords</resource>
+    <separator>&gt;</separator>
 </keywords>
 ----
 

--- a/doc/ch04-md-contrvocabs.adoc
+++ b/doc/ch04-md-contrvocabs.adoc
@@ -306,6 +306,24 @@ variable.
 
 <<keywords>>
 
+[[keywords-vocabulary]]
+=== Keywords Vocabulary
+
+
+[cols="2,3,5"]
+|============================================================================
+|Code | Vocabulary   | Resource
+
+|GCMDSK |GCMD Science Keywords | https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/sciencekeywords
+|GCMDLOC |GCMD Locations | https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/locations
+|GCMDPROV | GCMD Providers | https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/providers
+|CFSTDN | CF Standard Names | https://cfconventions.org/standard-names.html
+|GEMET | INSPIRE Themes | http://inspire.ec.europa.eu/theme
+|NORTHEMES |GeoNorge Themes | https://register.geonorge.no/subregister/metadata-kodelister/kartverket/nasjonal-temainndeling
+|============================================================================
+
+<<keywords>>
+
 [[platform-1]]
 === Platform
 

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -11,3 +11,8 @@ class TestXSDs(unittest.TestCase):
         xsd_schema = os.path.join(pathlib.Path.cwd(), 'xsd', 'mmd.xsd')
         xmlschema_mmd = ET.XMLSchema(ET.parse(xsd_schema))
         self.assertIsInstance(xmlschema_mmd, lxml.etree.XMLSchema)
+
+    def test_mmd_xsd_strict(self):
+        xsd_schema = os.path.join(pathlib.Path.cwd(), 'xsd', 'mmd_strict.xsd')
+        xmlschema_mmd = ET.XMLSchema(ET.parse(xsd_schema))
+        self.assertIsInstance(xmlschema_mmd, lxml.etree.XMLSchema)

--- a/xsd/mmd_strict.xsd
+++ b/xsd/mmd_strict.xsd
@@ -297,8 +297,18 @@
             <xs:element name="resource" type="xs:string" minOccurs="0"></xs:element>
             <xs:element name="separator" type="xs:string" minOccurs="0"></xs:element>
         </xs:sequence>
-        <xs:attribute name="vocabulary" type="xs:string"></xs:attribute>
+        <xs:attribute name="vocabulary" type="mmd:vocabulary_type"></xs:attribute>
     </xs:complexType>
+    <xs:simpleType name="vocabulary_type">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="GCMDSK"></xs:enumeration>
+            <xs:enumeration value="GCMDLOC"></xs:enumeration>
+            <xs:enumeration value="GCMDPROV"></xs:enumeration>
+            <xs:enumeration value="CFSTDN"></xs:enumeration>
+            <xs:enumeration value="GEMET"></xs:enumeration>
+            <xs:enumeration value="NORTHEMES"></xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
     <xs:complexType name="data_access_type">
         <xs:sequence>
             <xs:element name="name" type="xs:string" minOccurs="0"></xs:element>


### PR DESCRIPTION
This PR would upgrade the description of the keywords vocabulary attribute linking to suggested vocabulary that should be used now for reference. The schema for the internal mmd_strict.xsd is also updated. 
My suggestion would be to integrate this now and do a second upgrade of the xslt folder (opening a new issue) when we can polish the mmd records with the new list of vocabularies to avoid having to support both old (GCMD) and new (GCMDSK) nomenclature. 