### PR TITLE
Addition of Not available entry in controlled vocabulary

### DIFF
--- a/doc/ch04-md-contrvocabs.adoc
+++ b/doc/ch04-md-contrvocabs.adoc
@@ -84,6 +84,9 @@ been completed.
 
 |Obsolete |A new version of the dataset has been generated. The new
 version should be used, this is kept for back tracing.
+
+|Not available | The production status of the dataset is not available 
+or not provided.
 |=======================================================================
 
 <<dataset_production_status>>
@@ -102,6 +105,7 @@ version should be used, this is kept for back tracing.
 |planned |Planned
 |required |Planned
 |underDevelopment |Planned
+|Blank or element does not exist | Not available
 |===========================
 
 [[mmd-to-iso-mapping]]
@@ -115,6 +119,7 @@ version should be used, this is kept for back tracing.
 |In Work |onGoing
 |Complete |Complete
 |Obsolete |obsolete
+|Not available | Skip element 
 |==================
 
 [[operational-status]]
@@ -142,6 +147,9 @@ the first step in the process of becoming operational.
 |Scientific |This is used to describe purely scientific products. That
 is products generated through scientific projects and usually with a
 limited temporal perspective.
+
+|Not available | This is used when information on the operational status 
+is not available or not provided.
 |=======================================================================
 
 <<operational_status>>
@@ -275,6 +283,9 @@ time lapse photographic session of a specific site illustrating e.g.
 snow cover or cloud cover. It can also be used to tagdocuments or maps
 describing the nature of a field station. It would then require datasets
 to be linked (which currently is not supported).
+
+|Not available | This is used when information on the activity type is not 
+available or not provided.
 |=======================================================================
 
 <<activity_type>>
@@ -320,6 +331,7 @@ variable.
 |CFSTDN | CF Standard Names | https://cfconventions.org/standard-names.html
 |GEMET | INSPIRE Themes | http://inspire.ec.europa.eu/theme
 |NORTHEMES |GeoNorge Themes | https://register.geonorge.no/metadata-kodelister/nasjonal-temainndeling
+|None | - | -
 |============================================================================
 
 <<keywords>>
@@ -582,6 +594,8 @@ describing hydroelectricity, geothermal, solar, and nuclear sources of
 energy, water purification and distribution, sewage collection and
 disposal, electricity and gas distribution, data communication,
 telecommunication, radio, and communication networks.
+
+|Not available | The ISO topic category is not available or not provided.
 |=======================================================================
 
 <<iso_topic_category>>

--- a/thesauri/mmd-vocabulary.ttl
+++ b/thesauri/mmd-vocabulary.ttl
@@ -99,21 +99,25 @@
   skos:inScheme <https://vocab.met.no/mmd>; 
   skos:prefLabel "Dataset Production Status"@en ;
   skos:definition "Production status for the dataset."@en ;
-  skos:member <https://vocab.met.no/mmd/Dataset_Production_Status/Planned>, <https://vocab.met.no/mmd/Dataset_Production_Status/InWork>, <https://vocab.met.no/mmd/Dataset_Production_Status/Complete>, <https://vocab.met.no/mmd/Dataset_Production_Status/Obsolete> .
+  skos:changeNote "2022-03-16, Added Concept \"Not available\" in collection"@en ;
+  skos:member <https://vocab.met.no/mmd/Dataset_Production_Status/Planned>, <https://vocab.met.no/mmd/Dataset_Production_Status/InWork>, <https://vocab.met.no/mmd/Dataset_Production_Status/Complete>, <https://vocab.met.no/mmd/Dataset_Production_Status/Obsolete>, <https://vocab.met.no/mmd/Dataset_Production_Status/NotAvailable> .
 
 <https://vocab.met.no/mmd/Dataset_Production_Status/Planned>
   a skos:Concept ;
   skos:prefLabel "Planned"@en ;
+  skos:exactMatch <https://gcmd.earthdata.nasa.gov/kms/concept/0f1e9a71-9bda-43d6-86ef-f29472c36ebf> ;
   skos:definition "Refers to data sets to be collected in the future and are thus unavailable at the present time. For Example: The Hydro spacecraft has not been launched, but information on planned data sets may be available."@en .
 
 <https://vocab.met.no/mmd/Dataset_Production_Status/InWork>
   a skos:Concept ;
   skos:prefLabel "In Work"@en ;
+  skos:exactMatch <https://gcmd.earthdata.nasa.gov/kms/concept/946029f4-771c-4399-b0ed-e9e709f05fc1> ;
   skos:definition "Refers to data sets currently undergoing production or data that is continuously being collected or updated. For Example: data from the AIRS instrument on Aqua is being collected continuously."@en .
 
 <https://vocab.met.no/mmd/Dataset_Production_Status/Complete>
   a skos:Concept ;
   skos:prefLabel "Complete"@en ;
+  skos:exactMatch <https://gcmd.earthdata.nasa.gov/kms/concept/4607c5df-a8ed-415b-b962-d28e7583d1ef> ;
   skos:definition "Refers to data sets in which no updates or further data collection will be made. For Example: Nimbus-7 SMMR data collection has been completed."@en .
 
 <https://vocab.met.no/mmd/Dataset_Production_Status/Obsolete>
@@ -121,13 +125,19 @@
   skos:prefLabel "Obsolete"@en ;
   skos:definition "A new version of the dataset has been generated. The new version should be used, this is kept for back tracing."@en .
 
+<https://vocab.met.no/mmd/Dataset_Production_Status/NotAvailable>
+  a skos:Concept ;
+  skos:prefLabel "Not available"@en ;
+  skos:definition "The production status of the dataset is not available or not provided."@en .
+
 
 <https://vocab.met.no/mmd/Activity_Type>
   a skos:Collection, isothes:ConceptGroup;
   skos:inScheme <https://vocab.met.no/mmd>; 
   skos:prefLabel "Activity Type"@en ;
   skos:definition "Controlled vocabulary to be used in METAMOD context to describe activity types. Rather than using the term observation type or platform which possibly could describe the nature of observed datasets, activity type is used to filter between both observations and simulations that possibly are describing the same phenomena. Activity types are used to identify the origin of the dataset documented within METAMOD. This is not an identification of the observation platform (e.g. specific vessel, SYNOP station or satellite), but more the nature of the generation process (e.g. simulation, in situ observation, remote sensing etc). It is useful in the context of filtering data when searching for relevant datasets."@en ;
-  skos:member <https://vocab.met.no/mmd/Activity_Type/Aircraft>, <https://vocab.met.no/mmd/Activity_Type/SpaceBorneInstrument>, <https://vocab.met.no/mmd/Activity_Type/NumericalSimulation>, <https://vocab.met.no/mmd/Activity_Type/ClimateIndicator>, <https://vocab.met.no/mmd/Activity_Type/InSituLandBasedStation>, <https://vocab.met.no/mmd/Activity_Type/InSituShipBasedStation>, <https://vocab.met.no/mmd/Activity_Type/InSituOceanFixedStation>, <https://vocab.met.no/mmd/Activity_Type/InSituOceanMovingStation>, <https://vocab.met.no/mmd/Activity_Type/InSituIceBasedStation>, <https://vocab.met.no/mmd/Activity_Type/Interview-Questionnaire>, <https://vocab.met.no/mmd/Activity_Type/Maps-Charts-Photographs> .
+  skos:changeNote "2022-03-16, Added Concept \"Not available\" in collection"@en ;
+  skos:member <https://vocab.met.no/mmd/Activity_Type/Aircraft>, <https://vocab.met.no/mmd/Activity_Type/SpaceBorneInstrument>, <https://vocab.met.no/mmd/Activity_Type/NumericalSimulation>, <https://vocab.met.no/mmd/Activity_Type/ClimateIndicator>, <https://vocab.met.no/mmd/Activity_Type/InSituLandBasedStation>, <https://vocab.met.no/mmd/Activity_Type/InSituShipBasedStation>, <https://vocab.met.no/mmd/Activity_Type/InSituOceanFixedStation>, <https://vocab.met.no/mmd/Activity_Type/InSituOceanMovingStation>, <https://vocab.met.no/mmd/Activity_Type/InSituIceBasedStation>, <https://vocab.met.no/mmd/Activity_Type/Interview-Questionnaire>, <https://vocab.met.no/mmd/Activity_Type/Maps-Charts-Photographs>, <https://vocab.met.no/mmd/Activity_Type/NotAvailable> .
 
 <https://vocab.met.no/mmd/Activity_Type/Aircraft>
   a skos:Concept ;
@@ -194,6 +204,11 @@
   skos:altLabel "Maps"@en, "Charts"@en, "Photographs"@en ;
   skos:definition "This is used to tag datasets containing imagery or PDF documents. This could e.g. be a time lapse photographic session of a specific site illustrating e.g. snow cover or cloud cover. It can also be used to tag documents or maps describing the nature of a field station. It would then require datasets to be linked (which currently is not supported)."@en .
 
+<https://vocab.met.no/mmd/Activity_Type/NotAvailable>
+  a skos:Concept ;
+  skos:prefLabel "Not available"@en ;
+  skos:definition "This is used when information on the activity type is not available or not provided."@en .
+
 
 <https://vocab.met.no/mmd/ISO_Topic_Category>
   a skos:Collection, isothes:ConceptGroup ;
@@ -201,7 +216,8 @@
   skos:exactMatch <http://vocab.nerc.ac.uk/mmd/P05/current/> ;
   skos:prefLabel "ISO Topic Category"@en ;
   skos:definition "Terms defined by ISO describing data themes."@en ;
-  skos:member <https://vocab.met.no/mmd/ISO_Topic_Category/inlandWaters>, <https://vocab.met.no/mmd/ISO_Topic_Category/intelligenceMilitary>, <https://vocab.met.no/mmd/ISO_Topic_Category/climatologyMeteorologyAtmosphere>, <https://vocab.met.no/mmd/ISO_Topic_Category/utilitiesCommunications>, <https://vocab.met.no/mmd/ISO_Topic_Category/farming>, <https://vocab.met.no/mmd/ISO_Topic_Category/imageryBaseMapsEarthCover>, <https://vocab.met.no/mmd/ISO_Topic_Category/structure>, <https://vocab.met.no/mmd/ISO_Topic_Category/health>, <https://vocab.met.no/mmd/ISO_Topic_Category/elevation>, <https://vocab.met.no/mmd/ISO_Topic_Category/society>, <https://vocab.met.no/mmd/ISO_Topic_Category/environment>, <https://vocab.met.no/mmd/ISO_Topic_Category/extraTerrestrial>, <https://vocab.met.no/mmd/ISO_Topic_Category/biota>, <https://vocab.met.no/mmd/ISO_Topic_Category/disaster>, <https://vocab.met.no/mmd/ISO_Topic_Category/transportation>, <https://vocab.met.no/mmd/ISO_Topic_Category/geoscientificInformation>, <https://vocab.met.no/mmd/ISO_Topic_Category/oceans>, <https://vocab.met.no/mmd/ISO_Topic_Category/economy>, <https://vocab.met.no/mmd/ISO_Topic_Category/planningCadastre>, <https://vocab.met.no/mmd/ISO_Topic_Category/location>, <https://vocab.met.no/mmd/ISO_Topic_Category/boundaries> .
+  skos:changeNote "2022-03-16, Added Concept \"Not available\" in collection"@en ;
+  skos:member <https://vocab.met.no/mmd/ISO_Topic_Category/inlandWaters>, <https://vocab.met.no/mmd/ISO_Topic_Category/intelligenceMilitary>, <https://vocab.met.no/mmd/ISO_Topic_Category/climatologyMeteorologyAtmosphere>, <https://vocab.met.no/mmd/ISO_Topic_Category/utilitiesCommunications>, <https://vocab.met.no/mmd/ISO_Topic_Category/farming>, <https://vocab.met.no/mmd/ISO_Topic_Category/imageryBaseMapsEarthCover>, <https://vocab.met.no/mmd/ISO_Topic_Category/structure>, <https://vocab.met.no/mmd/ISO_Topic_Category/health>, <https://vocab.met.no/mmd/ISO_Topic_Category/elevation>, <https://vocab.met.no/mmd/ISO_Topic_Category/society>, <https://vocab.met.no/mmd/ISO_Topic_Category/environment>, <https://vocab.met.no/mmd/ISO_Topic_Category/extraTerrestrial>, <https://vocab.met.no/mmd/ISO_Topic_Category/biota>, <https://vocab.met.no/mmd/ISO_Topic_Category/disaster>, <https://vocab.met.no/mmd/ISO_Topic_Category/transportation>, <https://vocab.met.no/mmd/ISO_Topic_Category/geoscientificInformation>, <https://vocab.met.no/mmd/ISO_Topic_Category/oceans>, <https://vocab.met.no/mmd/ISO_Topic_Category/economy>, <https://vocab.met.no/mmd/ISO_Topic_Category/planningCadastre>, <https://vocab.met.no/mmd/ISO_Topic_Category/location>, <https://vocab.met.no/mmd/ISO_Topic_Category/boundaries>, <https://vocab.met.no/mmd/ISO_Topic_Category/NotAvailable> .
 
 <https://vocab.met.no/mmd/ISO_Topic_Category/inlandWaters>
   a skos:Concept ;
@@ -330,6 +346,11 @@
   skos:definition " Legal land descriptions, for example political and administrative boundaries, governmental units, marine boundaries, voting districts, school districts, international boundaries"@en ;
   skos:prefLabel "boundaries"@en ;
   skos:altLabel "BOUNDARIES"@en .
+
+<https://vocab.met.no/mmd/ISO_Topic_Category/NotAvailable>
+  a skos:Concept ;
+  skos:definition "The iso topic category is not available or not provided."@en ;
+  skos:prefLabel "Not available"@en .
 
 
 <https://vocab.met.no/mmd/Access_Constraint>
@@ -762,7 +783,8 @@
   skos:inScheme <https://vocab.met.no/mmd>; 
   skos:prefLabel "Operational Status"@en ;
   skos:definition "Controlled vocabulary to be used in METAMOD context to describe operational status of datasets handled. This is used in filtering of the information. Typically scientific datasets are generated without a temporal perspective and review process. The review process of scientific products is publications in refereed journals or in data citation papers. Experimental, Pre-Operational and Operational are concepts supported by institutions with a committment for a specific delivery over time."@en ;
-  skos:member <https://vocab.met.no/mmd/Operational_Status/Operational>, <https://vocab.met.no/mmd/Operational_Status/Pre-Operational>, <https://vocab.met.no/mmd/Operational_Status/Experimental>, <https://vocab.met.no/mmd/Operational_Status/Scientific> .
+  skos:changeNote "2022-03-16, Added Concept \"Not available\" in collection"@en ;
+  skos:member <https://vocab.met.no/mmd/Operational_Status/Operational>, <https://vocab.met.no/mmd/Operational_Status/Pre-Operational>, <https://vocab.met.no/mmd/Operational_Status/Experimental>, <https://vocab.met.no/mmd/Operational_Status/Scientific>, <https://vocab.met.no/mmd/Operational_Status/NotAvailable> .
 
 <https://vocab.met.no/mmd/Operational_Status/Operational>
   a skos:Concept ;
@@ -784,6 +806,11 @@
   skos:prefLabel "Scientific"@en ;
   skos:definition """This is used to describe purely scientific products. that is products generated through scientific projects and usually with a limited temporal perspective. 
         """@en .
+
+<https://vocab.met.no/mmd/Operational_Status/NotAvailable>
+  a skos:Concept ;
+  skos:prefLabel "Not available"@en ;
+  skos:definition "This is used when information on the operational status is not available or not provided."@en .
 
 <https://vocab.met.no/mmd/Collection_Keywords>
   a skos:Collection, isothes:ConceptGroup ;

--- a/thesauri/mmd-vocabulary.xml
+++ b/thesauri/mmd-vocabulary.xml
@@ -150,9 +150,11 @@
     <skos:inScheme rdf:resource="https://vocab.met.no/mmd"/>
     <skos:prefLabel xml:lang="en">Dataset Production Status</skos:prefLabel>
     <skos:definition xml:lang="en">Production status for the dataset.</skos:definition>
+    <skos:changeNote xml:lang="en">2022-03-16, Added Concept &quot;Not available&quot; in collection</skos:changeNote>
     <skos:member>
       <skos:Concept rdf:about="https://vocab.met.no/mmd/Dataset_Production_Status/Planned">
         <skos:prefLabel xml:lang="en">Planned</skos:prefLabel>
+        <skos:exactMatch rdf:resource="https://gcmd.earthdata.nasa.gov/kms/concept/0f1e9a71-9bda-43d6-86ef-f29472c36ebf"/>
         <skos:definition xml:lang="en">Refers to data sets to be collected in the future and are thus unavailable at the present time. For Example: The Hydro spacecraft has not been launched, but information on planned data sets may be available.</skos:definition>
       </skos:Concept>
     </skos:member>
@@ -160,6 +162,7 @@
     <skos:member>
       <skos:Concept rdf:about="https://vocab.met.no/mmd/Dataset_Production_Status/InWork">
         <skos:prefLabel xml:lang="en">In Work</skos:prefLabel>
+        <skos:exactMatch rdf:resource="https://gcmd.earthdata.nasa.gov/kms/concept/946029f4-771c-4399-b0ed-e9e709f05fc1"/>
         <skos:definition xml:lang="en">Refers to data sets currently undergoing production or data that is continuously being collected or updated. For Example: data from the AIRS instrument on Aqua is being collected continuously.</skos:definition>
       </skos:Concept>
     </skos:member>
@@ -167,6 +170,7 @@
     <skos:member>
       <skos:Concept rdf:about="https://vocab.met.no/mmd/Dataset_Production_Status/Complete">
         <skos:prefLabel xml:lang="en">Complete</skos:prefLabel>
+        <skos:exactMatch rdf:resource="https://gcmd.earthdata.nasa.gov/kms/concept/4607c5df-a8ed-415b-b962-d28e7583d1ef"/>
         <skos:definition xml:lang="en">Refers to data sets in which no updates or further data collection will be made. For Example: Nimbus-7 SMMR data collection has been completed.</skos:definition>
       </skos:Concept>
     </skos:member>
@@ -178,6 +182,12 @@
       </skos:Concept>
     </skos:member>
 
+    <skos:member>
+      <skos:Concept rdf:about="https://vocab.met.no/mmd/Dataset_Production_Status/NotAvailable">
+        <skos:prefLabel xml:lang="en">Not available</skos:prefLabel>
+        <skos:definition xml:lang="en">The production status of the dataset is not available or not provided.</skos:definition>
+      </skos:Concept>
+    </skos:member>
   </skos:Collection>
 
   <skos:Collection rdf:about="https://vocab.met.no/mmd/Activity_Type">
@@ -185,6 +195,7 @@
     <skos:inScheme rdf:resource="https://vocab.met.no/mmd"/>
     <skos:prefLabel xml:lang="en">Activity Type</skos:prefLabel>
     <skos:definition xml:lang="en">Controlled vocabulary to be used in METAMOD context to describe activity types. Rather than using the term observation type or platform which possibly could describe the nature of observed datasets, activity type is used to filter between both observations and simulations that possibly are describing the same phenomena. Activity types are used to identify the origin of the dataset documented within METAMOD. This is not an identification of the observation platform (e.g. specific vessel, SYNOP station or satellite), but more the nature of the generation process (e.g. simulation, in situ observation, remote sensing etc). It is useful in the context of filtering data when searching for relevant datasets.</skos:definition>
+    <skos:changeNote xml:lang="en">2022-03-16, Added Concept &quot;Not available&quot; in collection</skos:changeNote>
     <skos:member>
       <skos:Concept rdf:about="https://vocab.met.no/mmd/Activity_Type/Aircraft">
         <skos:prefLabel xml:lang="en">Aircraft</skos:prefLabel>
@@ -275,6 +286,12 @@
       </skos:Concept>
     </skos:member>
 
+    <skos:member>
+      <skos:Concept rdf:about="https://vocab.met.no/mmd/Activity_Type/NotAvailable">
+        <skos:prefLabel xml:lang="en">Not available</skos:prefLabel>
+        <skos:definition xml:lang="en">This is used when information on the activity type is not available or not provided.</skos:definition>
+      </skos:Concept>
+    </skos:member>
   </skos:Collection>
 
   <skos:Collection rdf:about="https://vocab.met.no/mmd/ISO_Topic_Category">
@@ -283,6 +300,7 @@
     <skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/mmd/P05/current/"/>
     <skos:prefLabel xml:lang="en">ISO Topic Category</skos:prefLabel>
     <skos:definition xml:lang="en">Terms defined by ISO describing data themes.</skos:definition>
+    <skos:changeNote xml:lang="en">2022-03-16, Added Concept &quot;Not available&quot; in collection</skos:changeNote>
     <skos:member>
       <skos:Concept rdf:about="https://vocab.met.no/mmd/ISO_Topic_Category/inlandWaters">
         <skos:exactMatch rdf:resource="http://vocab.nerc.ac.uk/mmd/P05/current/002/"/>
@@ -454,6 +472,12 @@
       </skos:Concept>
     </skos:member>
 
+    <skos:member>
+      <skos:Concept rdf:about="https://vocab.met.no/mmd/ISO_Topic_Category/NotAvailable">
+        <skos:definition xml:lang="en">The iso topic category is not available or not provided.</skos:definition>
+        <skos:prefLabel xml:lang="en">Not available</skos:prefLabel>
+      </skos:Concept>
+    </skos:member>
   </skos:Collection>
 
   <skos:Collection rdf:about="https://vocab.met.no/mmd/Access_Constraint">
@@ -1020,6 +1044,7 @@
     <skos:inScheme rdf:resource="https://vocab.met.no/mmd"/>
     <skos:prefLabel xml:lang="en">Operational Status</skos:prefLabel>
     <skos:definition xml:lang="en">Controlled vocabulary to be used in METAMOD context to describe operational status of datasets handled. This is used in filtering of the information. Typically scientific datasets are generated without a temporal perspective and review process. The review process of scientific products is publications in refereed journals or in data citation papers. Experimental, Pre-Operational and Operational are concepts supported by institutions with a committment for a specific delivery over time.</skos:definition>
+    <skos:changeNote xml:lang="en">2022-03-16, Added Concept &quot;Not available&quot; in collection</skos:changeNote>
     <skos:member>
       <skos:Concept rdf:about="https://vocab.met.no/mmd/Operational_Status/Operational">
         <skos:prefLabel xml:lang="en">Operational</skos:prefLabel>
@@ -1049,6 +1074,12 @@
       </skos:Concept>
     </skos:member>
 
+    <skos:member>
+      <skos:Concept rdf:about="https://vocab.met.no/mmd/Operational_Status/NotAvailable">
+        <skos:prefLabel xml:lang="en">Not available</skos:prefLabel>
+        <skos:definition xml:lang="en">This is used when information on the operational status is not available or not provided.</skos:definition>
+      </skos:Concept>
+    </skos:member>
   </skos:Collection>
 
   <skos:Collection rdf:about="https://vocab.met.no/mmd/Collection_Keywords">

--- a/xsd/mmd.xsd
+++ b/xsd/mmd.xsd
@@ -225,6 +225,7 @@
             <xs:enumeration value="In Work"></xs:enumeration>
             <xs:enumeration value="Complete"></xs:enumeration>
             <xs:enumeration value="Obsolete"></xs:enumeration>
+            <xs:enumeration value="Not available"></xs:enumeration>
         </xs:restriction>
     </xs:simpleType>
     <xs:simpleType name="iso_topic_category_type">
@@ -248,6 +249,7 @@
             <xs:enumeration value="structure"></xs:enumeration>
             <xs:enumeration value="transportation"></xs:enumeration>
             <xs:enumeration value="utilitiesCommunications"></xs:enumeration>
+            <xs:enumeration value="Not available"></xs:enumeration>
         </xs:restriction>
     </xs:simpleType>
     <xs:complexType name="platform_type">
@@ -388,6 +390,7 @@
             <xs:enumeration value="Pre-Operational"></xs:enumeration>
             <xs:enumeration value="Experimental"></xs:enumeration>
             <xs:enumeration value="Scientific"/>
+            <xs:enumeration value="Not available"/>
         </xs:restriction>
     </xs:simpleType>
     <xs:complexType name="related_information_type">

--- a/xslt/dif-to-mmd.xsl
+++ b/xslt/dif-to-mmd.xsl
@@ -12,7 +12,7 @@ Meaning this should consume both DIF 8, 9 and 10.
     xmlns:skos="http://www.w3.org/2004/02/skos/core#"
     version="1.0">
     <xsl:output method="xml" encoding="UTF-8" indent="yes"/>
-    <xsl:key name="isoc" match="skos:Concept" use="skos:altLabel"/>
+    <xsl:key name="isoc" match="skos:Collection[@rdf:about='https://vocab.met.no/mmd/ISO_Topic_Category']/skos:member/skos:Concept" use="skos:altLabel"/>
     <xsl:variable name="isoLUD" select="document('../thesauri/mmd-vocabulary.xml')"/>
     <!--
     <xsl:key name="isoc" match="Concept" use="altLabel"/>
@@ -25,13 +25,31 @@ Meaning this should consume both DIF 8, 9 and 10.
             <xsl:apply-templates select="dif:Summary" />
             <xsl:apply-templates select="dif:Personnel" />
             <xsl:element name="mmd:metadata_status">Active</xsl:element>
-            <xsl:apply-templates select="dif:Data_Set_Progress" />
+	    <xsl:element name="mmd:dataset_production_status">
+		<xsl:choose>
+		    <xsl:when test="dif:Data_Set_Progress">
+                        <xsl:apply-templates select="dif:Data_Set_Progress" />
+		    </xsl:when>
+		    <xsl:otherwise>
+			<xsl:text>Not available</xsl:text>
+		    </xsl:otherwise>
+		</xsl:choose>
+	    </xsl:element>
             <xsl:element name="mmd:collection">ADC</xsl:element>
             <xsl:apply-templates select="dif:Last_DIF_Revision_Date" />
             <xsl:apply-templates select="dif:Temporal_Coverage" />
-            <xsl:apply-templates select="dif:ISO_Topic_Category" />
+	    <xsl:element name="mmd:iso_topic_category">
+		<xsl:choose>
+		    <xsl:when test="dif:ISO_Topic_Category">
+                        <xsl:apply-templates select="dif:ISO_Topic_Category" />
+		    </xsl:when>
+		    <xsl:otherwise>
+			<xsl:text>Not available</xsl:text>
+		    </xsl:otherwise>
+		</xsl:choose>
+	    </xsl:element>
             <xsl:element name="mmd:keywords">
-                <xsl:attribute name="vocabulary">gcmd</xsl:attribute>
+                <xsl:attribute name="vocabulary">GCMDSK</xsl:attribute>
                 <xsl:apply-templates select="dif:Parameters" />
             </xsl:element>
             <xsl:element name="mmd:keywords">
@@ -134,14 +152,12 @@ Meaning this should consume both DIF 8, 9 and 10.
   </xsl:template>
 
   <xsl:template match="dif:ISO_Topic_Category">
-      <xsl:element name="mmd:iso_topic_category">
-          <xsl:variable name="isov" select="." />
-          <xsl:for-each select="$isoLUD">
-              <xsl:value-of select ="name()" />
-              <xsl:variable name="isoe" select="key('isoc',$isov)/skos:prefLabel"/>
-              <xsl:value-of select="$isoe"/>
-          </xsl:for-each>
-      </xsl:element>
+      <xsl:variable name="isov" select="." />
+      <xsl:for-each select="$isoLUD">
+          <xsl:value-of select ="name()" />
+          <xsl:variable name="isoe" select="key('isoc',$isov)/skos:prefLabel"/>
+          <xsl:value-of select="$isoe"/>
+      </xsl:for-each>
   </xsl:template>
 
 
@@ -159,9 +175,7 @@ Meaning this should consume both DIF 8, 9 and 10.
   </xsl:template>
 
   <xsl:template match="dif:Data_Set_Progress">
-      <xsl:element name="mmd:dataset_production_status">
-          <xsl:value-of select="." />
-      </xsl:element>
+      <xsl:value-of select="." />
   </xsl:template>
 
   <xsl:template match="dif:Temporal_Coverage">

--- a/xslt/ecmwf-iso-to-mmd.xsl
+++ b/xslt/ecmwf-iso-to-mmd.xsl
@@ -24,8 +24,26 @@
             <xsl:apply-templates select="gmd:identificationInfo/gmd:MD_DataIdentification/gmd:abstract" />
             <xsl:apply-templates select="gmd:fileIdentifier/gco:CharacterString" />
             <xsl:apply-templates select="gmd:identificationInfo/gmd:MD_DataIdentification/gmd:language" />
-            <xsl:apply-templates select="gmd:identificationInfo/gmd:MD_DataIdentification/gmd:status"/>
-            <xsl:apply-templates select="gmd:identificationInfo/gmd:MD_DataIdentification/gmd:topicCategory/gmd:MD_TopicCategoryCode" />
+	    <xsl:element name="mmd:dataset_production_status">
+		<xsl:choose>
+		    <xsl:when test="gmd:identificationInfo/gmd:MD_DataIdentification/gmd:status">
+                        <xsl:apply-templates select="gmd:identificationInfo/gmd:MD_DataIdentification/gmd:status"/>
+		    </xsl:when>
+		    <xsl:otherwise>
+			<xsl:text>Not available</xsl:text>
+		    </xsl:otherwise>
+		</xsl:choose>
+	    </xsl:element>
+	    <xsl:element name="mmd:iso_topic_category">
+		<xsl:choose>
+		    <xsl:when test="gmd:identificationInfo/gmd:MD_DataIdentification/gmd:topicCategory/gmd:MD_TopicCategoryCode">
+                        <xsl:apply-templates select="gmd:identificationInfo/gmd:MD_DataIdentification/gmd:topicCategory/gmd:MD_TopicCategoryCode" />
+		    </xsl:when>
+		    <xsl:otherwise>
+			<xsl:text>Not available</xsl:text>
+		    </xsl:otherwise>
+		</xsl:choose>
+	    </xsl:element>
             <xsl:apply-templates select="gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent/gmd:temporalElement/gmd:EX_TemporalExtent/gmd:extent" />
             
             <xsl:apply-templates select="gmd:contact/gmd:CI_ResponsibleParty" />
@@ -84,9 +102,7 @@
         <xsl:variable name="iso_status" select="normalize-space(gmd:MD_ProgressCode/@codeListValue)" />
         <xsl:variable name="iso_status_mapping" select="document('')/*/mapping:dataset_status[@iso=$iso_status]" />
         <xsl:value-of select="$iso_status_mapping" />
-        <xsl:element name="mmd:dataset_production_status">
-            <xsl:value-of select="$iso_status_mapping/@mmd"></xsl:value-of>                    
-        </xsl:element>    
+        <xsl:value-of select="$iso_status_mapping/@mmd"></xsl:value-of>
     </xsl:template>
 
 
@@ -100,9 +116,7 @@
     <mapping:dataset_status iso="underDevelopment" mmd="Planned" />
 
     <xsl:template match="gmd:identificationInfo/gmd:MD_DataIdentification/gmd:topicCategory/gmd:MD_TopicCategoryCode">
-        <xsl:element name="mmd:iso_topic_category">
-            <xsl:value-of select="." />
-        </xsl:element>
+        <xsl:value-of select="." />
     </xsl:template>    
     
     <xsl:template match="gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent/gmd:temporalElement/gmd:EX_TemporalExtent/gmd:extent">    
@@ -253,7 +267,7 @@
     <xsl:template match="gmd:descriptiveKeywords/gmd:MD_Keywords">
     
         <xsl:element name="mmd:keywords">
-            <xsl:attribute name="vocabulary">none</xsl:attribute>
+            <xsl:attribute name="vocabulary">None</xsl:attribute>
             <xsl:apply-templates select="gmd:keyword" />
         </xsl:element>
     

--- a/xslt/iso-to-mmd.xsl
+++ b/xslt/iso-to-mmd.xsl
@@ -24,23 +24,36 @@
             <xsl:apply-templates select="gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation" />
             <xsl:apply-templates select="gmd:identificationInfo/gmd:MD_DataIdentification/gmd:abstract" />
             <xsl:element name="mmd:metadata_status">Active</xsl:element>
-            <xsl:apply-templates select="gmd:identificationInfo/gmd:MD_DataIdentification/gmd:status"/>
-            <!-- If /gmd:MD_Metadata/gmd:status is not available, check
-                 further and add default -->
-<!-- for test purposes...
-            <mmd:dataset_production_status>In Work</mmd:dataset_production_status>
--->
+	    <xsl:element name="mmd:dataset_production_status">
+                <xsl:choose>
+                    <xsl:when test="gmd:identificationInfo/gmd:MD_DataIdentification/gmd:status">
+                        <xsl:apply-templates select="gmd:identificationInfo/gmd:MD_DataIdentification/gmd:status"/>
+                   </xsl:when>
+                   <xsl:otherwise>
+	               <xsl:text>Not available</xsl:text>
+                   </xsl:otherwise>
+                </xsl:choose>
+	    </xsl:element>
+	    <xsl:element name="mmd:iso_topic_category">
+		<xsl:choose>
+		    <xsl:when test="gmd:identificationInfo/gmd:MD_DataIdentification/gmd:topicCategory/gmd:MD_TopicCategoryCode">
+                        <xsl:apply-templates select="gmd:identificationInfo/gmd:MD_DataIdentification/gmd:topicCategory/gmd:MD_TopicCategoryCode" />
+		    </xsl:when>
+		    <xsl:otherwise>
+			<xsl:text>Not available</xsl:text>
+		    </xsl:otherwise>
+		</xsl:choose>
+	    </xsl:element>
             <xsl:element name="mmd:collection">ADC</xsl:element>
             <xsl:apply-templates select="gmd:dateStamp" />
             <xsl:apply-templates select="gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent/gmd:temporalElement/gmd:EX_TemporalExtent/gmd:extent" />
-            <xsl:apply-templates select="gmd:identificationInfo/gmd:MD_DataIdentification/gmd:topicCategory/gmd:MD_TopicCategoryCode" />
             <xsl:apply-templates select="gmd:identificationInfo/gmd:MD_DataIdentification/gmd:descriptiveKeywords/gmd:MD_Keywords[./gmd:keyword/gmd:type/gmd:MD_KeywordTypeCode = 'project']" />
             <xsl:element name="mmd:keywords">
-                <xsl:attribute name="vocabulary">gcmd</xsl:attribute>
+                <xsl:attribute name="vocabulary">GCMDSK</xsl:attribute>
                 <xsl:apply-templates select="gmd:identificationInfo/gmd:MD_DataIdentification/gmd:descriptiveKeywords/gmd:MD_Keywords/gmd:keyword/gco:CharacterString[contains(.,'EARTH SCIENCE &gt;')]" />
             </xsl:element>
             <xsl:element name="mmd:keywords">
-                <xsl:attribute name="vocabulary">none</xsl:attribute>
+                <xsl:attribute name="vocabulary">None</xsl:attribute>
                 <xsl:apply-templates select="gmd:identificationInfo/gmd:MD_DataIdentification/gmd:descriptiveKeywords/gmd:MD_Keywords/gmd:keyword/gco:CharacterString[not(contains(.,'EARTH SCIENCE &gt;'))]" />
             </xsl:element>
             <!--
@@ -135,12 +148,10 @@
     </xsl:template>
 
     <xsl:template match="gmd:status">        
-        <xsl:variable name="iso_status" select="normalize-space(gmd:MD_ProgressCode)" />
+        <xsl:variable name="iso_status" select="normalize-space(gmd:MD_ProgressCode/@codeListValue)" />
         <xsl:variable name="iso_status_mapping" select="document('')/*/mapping:dataset_status[@iso=$iso_status]" />
         <xsl:value-of select="$iso_status_mapping" />
-        <xsl:element name="mmd:dataset_production_status">
-            <xsl:value-of select="$iso_status_mapping/@mmd"></xsl:value-of>                    
-        </xsl:element>    
+        <xsl:value-of select="$iso_status_mapping/@mmd"></xsl:value-of>
     </xsl:template>
 
     <!-- mapping between iso and mmd dataset statuses -->
@@ -153,9 +164,7 @@
     <mapping:dataset_status iso="underDevelopment" mmd="Planned" />
 
     <xsl:template match="gmd:identificationInfo/gmd:MD_DataIdentification/gmd:topicCategory/gmd:MD_TopicCategoryCode">
-        <xsl:element name="mmd:iso_topic_category">
-            <xsl:value-of select="." />
-        </xsl:element>
+        <xsl:value-of select="." />
     </xsl:template>    
     
     <xsl:template match="gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent/gmd:temporalElement/gmd:EX_TemporalExtent/gmd:extent">    

--- a/xslt/mmd-to-dif.xsl
+++ b/xslt/mmd-to-dif.xsl
@@ -30,11 +30,11 @@
                         </xsl:choose>
                         <xsl:apply-templates select="mmd:personnel[mmd:role !='Data center contact']" />
 			<xsl:apply-templates select="mmd:keywords[@vocabulary = 'GCMDSK']" />
-			<xsl:apply-templates select="mmd:iso_topic_category" />
+			<xsl:apply-templates select="mmd:iso_topic_category[. != 'Not available']" />
 			<xsl:apply-templates select="mmd:keywords[not(@vocabulary = 'GCMDSK' or @vocabulary = 'GCMDLOC')]" />
 			<xsl:apply-templates select="mmd:platform" />
 			<xsl:apply-templates select="mmd:temporal_extent" />
-			<xsl:apply-templates select="mmd:dataset_production_status" />
+			<xsl:apply-templates select="mmd:dataset_production_status[. != 'Not available']" />
 			<xsl:apply-templates select="mmd:geographic_extent/mmd:rectangle" />
 			<xsl:apply-templates select="mmd:keywords[@vocabulary = 'GCMDLOC']" />
 			<xsl:apply-templates select="mmd:location" />

--- a/xslt/mmd-to-dif10.xsl
+++ b/xslt/mmd-to-dif10.xsl
@@ -1,43 +1,86 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-	xmlns:dif="http://gcmd.gsfc.nasa.gov/Aboutus/xml/dif/" xmlns:mmd="http://www.met.no/schema/mmd"
+	xmlns:dif="http://gcmd.gsfc.nasa.gov/Aboutus/xml/dif/"
+	xmlns:mmd="http://www.met.no/schema/mmd"
+        xmlns:mapping="http://www.met.no/schema/mmd/mmd2dif"
 	xmlns:dc="http://purl.org/dc/elements/1.1/" version="1.0">
 	<xsl:output method="xml" encoding="UTF-8" indent="yes" />
 
 	<xsl:template match="/mmd:mmd">
 		<xsl:element name="dif:DIF">
 			<xsl:apply-templates select="mmd:metadata_identifier" />
-			<xsl:apply-templates select="mmd:title" />
-			<xsl:apply-templates select="mmd:abstract" />
-			<xsl:apply-templates select="mmd:last_metadata_update" />
-			<xsl:apply-templates select="mmd:iso_topic_category" />
-			<xsl:apply-templates select="mmd:keywords" />
-			<xsl:apply-templates select="mmd:project" />
-			<xsl:apply-templates select="mmd:instrument" />
-			<xsl:apply-templates select="mmd:platform" />
+			<xsl:apply-templates select="mmd:title[@xml:lang = 'en']" />
+                        <xsl:choose>
+                            <xsl:when test="mmd:dataset_citation">
+                                <xsl:apply-templates select="mmd:dataset_citation" />
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <xsl:element name="dif:Dataset_Citation">
+                                    <xsl:element name="dif:Dataset_Title">
+				        <xsl:if test="mmd:title[@xml:lang = 'en'] or not(mmd:title[@xml:lang]) or mmd:title[@xml:lang = '']">
+				            <xsl:value-of select="mmd:title" />
+	                                </xsl:if>
+                                    </xsl:element>
+                                    <xsl:element name="dif:Online_Resource">
+				        <xsl:value-of select="mmd:related_information[mmd:type='Dataset landing page']/mmd:resource"/>
+                                    </xsl:element>
+                                </xsl:element>
+                            </xsl:otherwise>
+                        </xsl:choose>
+			<xsl:apply-templates select="mmd:personnel[mmd:role !='Data center contact']" />
+			<xsl:apply-templates select="mmd:keywords[@vocabulary = 'GCMDSK']" />
+			<xsl:apply-templates select="mmd:iso_topic_category[. != 'Not available']" />
+			<xsl:apply-templates select="mmd:keywords[not(@vocabulary = 'GCMDSK' or @vocabulary = 'GCMDLOC')]" />
+			<xsl:choose>
+			    <xsl:when test="mmd:platform">
+			        <xsl:apply-templates select="mmd:platform" />
+			    </xsl:when>
+			    <xsl:otherwise>
+		                <xsl:element name="dif:Platform">
+			            <xsl:element name="dif:Type">
+				        <xsl:text>Not provided</xsl:text>
+			            </xsl:element>
+			            <xsl:element name="dif:Short_Name">
+				        <xsl:text></xsl:text>
+			            </xsl:element>
+			            <xsl:element name="dif:Instrument">
+			                <xsl:element name="dif:Short_Name">
+				            <xsl:text></xsl:text>
+			                </xsl:element>
+			            </xsl:element>
+			        </xsl:element>
+			    </xsl:otherwise>
+			</xsl:choose>
 			<xsl:apply-templates select="mmd:temporal_extent" />
+			<xsl:apply-templates select="mmd:dataset_production_status" />
 			<xsl:apply-templates select="mmd:geographic_extent/mmd:rectangle" />
-			<xsl:apply-templates select="mmd:data_access" />
-			<xsl:apply-templates select="mmd:data_center" />
-			<xsl:apply-templates select="mmd:dataset_citation" />
+			<xsl:apply-templates select="mmd:keywords[@vocabulary = 'GCMDLOC']" />
+			<xsl:apply-templates select="mmd:project" />
+			<xsl:apply-templates select="mmd:quality_control" />
 			<xsl:apply-templates select="mmd:access_constraint" />
 			<xsl:apply-templates select="mmd:use_constraint" />
-			<xsl:apply-templates select="mmd:dataset_production_status" />
 			<xsl:apply-templates select="mmd:dataset_language" />
+			<xsl:apply-templates select="mmd:data_center" /> <!--tbd-->
+			<xsl:apply-templates select="mmd:abstract[@xml:lang = 'en']" />
+			<xsl:apply-templates select="mmd:related_information"/> <!--tbd-->
+			<xsl:apply-templates select="mmd:data_access" />
 
-			<xsl:element name="dif:Metadata_Name">
-				CEOS IDN DIF
-			</xsl:element>
-			<xsl:element name="dif:Metadata_Version">
-				9.7
-			</xsl:element>
+			<xsl:element name="dif:Metadata_Name">CEOS IDN DIF</xsl:element>
+			<xsl:element name="dif:Metadata_Version">VERSION 10.3</xsl:element>
+			<xsl:apply-templates select="mmd:last_metadata_update" />
+			<xsl:element name="dif:Product_Level_Id">Not provided</xsl:element>
 		</xsl:element>
 	</xsl:template>
 
 	<xsl:template match="mmd:metadata_identifier">
 		<xsl:element name="dif:Entry_ID">
+		    <xsl:element name="dif:Short_Name">
 			<xsl:value-of select="." />
+		    </xsl:element>
+		    <xsl:element name="dif:Version">
+                        <xsl:text>1.0</xsl:text>
+		    </xsl:element>
 		</xsl:element>
 	</xsl:template>
 
@@ -52,66 +95,425 @@
 			<xsl:element name="dif:Abstract">
 				<xsl:value-of select="." />
 			</xsl:element>
-			<xsl:element name="dif:Purpose" />
 		</xsl:element>
 	</xsl:template>
+
+	<xsl:template match="mmd:related_information">
+		<xsl:if test="mmd:type = 'Dataset landing page'">
+                    <xsl:element name="dif:Related_URL">
+                        <xsl:element name="dif:URL_Content_Type">
+                            <xsl:element name="dif:Type">
+                                <xsl:text>DATASET LANDING PAGE</xsl:text>
+                            </xsl:element>
+                        </xsl:element>
+                        <xsl:element name="dif:URL">
+                            <xsl:value-of select="mmd:resource"/>
+                        </xsl:element>
+                        <xsl:element name="dif:Description">
+                            <xsl:value-of select="mmd:description"/>
+                        </xsl:element>
+                    </xsl:element>
+	        </xsl:if>
+		<xsl:if test="mmd:type = 'Project home page'">
+                    <xsl:element name="dif:Related_URL">
+                        <xsl:element name="dif:URL_Content_Type">
+                            <xsl:element name="dif:Type">
+                                <xsl:text>PROJECT HOME PAGE</xsl:text>
+                            </xsl:element>
+                        </xsl:element>
+                        <xsl:element name="dif:URL">
+                            <xsl:value-of select="mmd:resource"/>
+                        </xsl:element>
+                        <xsl:element name="dif:Description">
+                            <xsl:value-of select="mmd:description"/>
+                        </xsl:element>
+                    </xsl:element>
+	        </xsl:if>
+		<xsl:if test="mmd:type = 'Users guide'">
+                    <xsl:element name="dif:Related_URL">
+                        <xsl:element name="dif:URL_Content_Type">
+                            <xsl:element name="dif:Type">
+                                <xsl:text>VIEW RELATED INFORMATION</xsl:text>
+                            </xsl:element>
+                            <xsl:element name="dif:Subtype">
+                                <xsl:text>USER'S GUIDE</xsl:text>
+                            </xsl:element>
+                        </xsl:element>
+                        <xsl:element name="dif:URL">
+                            <xsl:value-of select="mmd:resource"/>
+                        </xsl:element>
+                        <xsl:element name="dif:Description">
+                            <xsl:value-of select="mmd:description"/>
+                        </xsl:element>
+                    </xsl:element>
+	        </xsl:if>
+		<xsl:if test="mmd:type = 'Extended metadata'">
+                    <xsl:element name="dif:Related_URL">
+                        <xsl:element name="dif:URL_Content_Type">
+                            <xsl:element name="dif:Type">
+                                <xsl:text>EXTENDED METADATA</xsl:text>
+                            </xsl:element>
+                        </xsl:element>
+                        <xsl:element name="dif:URL">
+                            <xsl:value-of select="mmd:resource"/>
+                        </xsl:element>
+                        <xsl:element name="dif:Description">
+                            <xsl:value-of select="mmd:description"/>
+                        </xsl:element>
+                    </xsl:element>
+	        </xsl:if>
+		<xsl:if test="mmd:type = 'Scientific publication' or mmd:type = 'Data paper'">
+                    <xsl:element name="dif:Related_URL">
+                        <xsl:element name="dif:URL_Content_Type">
+                            <xsl:element name="dif:Type">
+                                <xsl:text>VIEW RELATED INFORMATION</xsl:text>
+                            </xsl:element>
+                            <xsl:element name="dif:Subtype">
+                                <xsl:text>PUBLICATIONS</xsl:text>
+                            </xsl:element>
+                        </xsl:element>
+                        <xsl:element name="dif:URL">
+                            <xsl:value-of select="mmd:resource"/>
+                        </xsl:element>
+                        <xsl:element name="dif:Description">
+                            <xsl:value-of select="mmd:description"/>
+                        </xsl:element>
+                    </xsl:element>
+	        </xsl:if>
+		<xsl:if test="mmd:type = 'Other documentation'">
+                    <xsl:element name="dif:Related_URL">
+                        <xsl:element name="dif:URL_Content_Type">
+                            <xsl:element name="dif:Type">
+                                <xsl:text>VIEW RELATED INFORMATION</xsl:text>
+                            </xsl:element>
+                            <xsl:element name="dif:Subtype">
+                                <xsl:text>GENERAL DOCUMENTATION</xsl:text>
+                            </xsl:element>
+                        </xsl:element>
+                        <xsl:element name="dif:URL">
+                            <xsl:value-of select="mmd:resource"/>
+                        </xsl:element>
+                        <xsl:element name="dif:Description">
+                            <xsl:value-of select="mmd:description"/>
+                        </xsl:element>
+                    </xsl:element>
+	        </xsl:if>
+        </xsl:template>
 
 	<xsl:template match="mmd:last_metadata_update">
-		<xsl:element name="dif:Last_DIF_Revision_Date">
-			<xsl:value-of select="." />
+            <xsl:element name="dif:Metadata_Dates">
+		<xsl:element name="dif:Metadata_Creation">
+		<xsl:choose>
+		    <xsl:when test="mmd:update/mmd:type = 'Created'">
+		        <xsl:value-of select="mmd:update/mmd:datetime"/>
+		    </xsl:when>
+		    <xsl:otherwise>
+	                <xsl:variable name="first">
+	                    <xsl:for-each select="mmd:update/mmd:datetime">
+                                <xsl:sort select="." order="ascending" />
+                                <xsl:if test="position() = 1">
+                                    <xsl:value-of select="."/>
+                                </xsl:if>
+                            </xsl:for-each>
+                        </xsl:variable>
+                        <xsl:value-of select="$first"/>
+		    </xsl:otherwise>
+		</xsl:choose>
 		</xsl:element>
+		<xsl:element name="dif:Metadata_Last_Revision">
+	            <xsl:variable name="latest">
+	                <xsl:for-each select="mmd:update/mmd:datetime">
+                            <xsl:sort select="." order="descending" />
+                            <xsl:if test="position() = 1">
+                                <xsl:value-of select="."/>
+                            </xsl:if>
+                        </xsl:for-each>
+                    </xsl:variable>
+                    <xsl:value-of select="$latest"/>
+		</xsl:element>
+            </xsl:element>
 	</xsl:template>
 
-	<xsl:template match="mmd:keywords">
-		<xsl:for-each select="mmd:keyword">
-			<xsl:element name="dif:Keyword">
-				<xsl:value-of select="." />
-			</xsl:element>
-		</xsl:for-each>
-	</xsl:template>
+        <xsl:template match="mmd:keywords[@vocabulary = 'GCMDSK']">
+            <xsl:for-each select="mmd:keyword">
+                <xsl:element name="dif:Science_Keywords">
+                    <xsl:variable name="mykeywordstring">
+                        <xsl:choose>
+                            <xsl:when test="not(contains(.,'EARTH SCIENCE') or contains(.,'Earth Science'))">
+                                <xsl:value-of select="."/>
+                            </xsl:when>
+                            <xsl:otherwise>
+				<xsl:if test="contains(.,'EARTH SCIENCE')">
+                                    <xsl:value-of select="substring-after(.,'EARTH SCIENCE &gt; ')"/>
+			        </xsl:if>
+				<xsl:if test="contains(.,'Earth Science')">
+                                    <xsl:value-of select="substring-after(.,'Earth Science &gt; ')"/>
+			        </xsl:if>
+                            </xsl:otherwise>
+                        </xsl:choose>
+                    </xsl:variable>
+                    <xsl:element name="dif:Category">
+                        <xsl:text>EARTH SCIENCE</xsl:text>
+                    </xsl:element>
+                    <xsl:call-template name="keywordseparation">
+                        <xsl:with-param name="keywordstring" select="(translate($mykeywordstring, 'abcdefghijklmnopqrstuvwxyz', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'))" />
+                    </xsl:call-template>
+                </xsl:element>
+            </xsl:for-each>
+        </xsl:template>
+        <!-- Template to split keywords into the sub elements DIF require -->
+        <xsl:variable name="separator">
+            <xsl:text> &gt; </xsl:text>
+        </xsl:variable>
+        <xsl:template name="keywordseparation">
+            <xsl:param name="keywordstring"/>
+            <xsl:choose>
+                <xsl:when test="contains($keywordstring,$separator)">
+                    <xsl:element name="dif:Topic">
+                        <xsl:value-of select="substring-before($keywordstring,$separator)"/>
+                    </xsl:element>
+                    <xsl:variable name="tmpstr1">
+                        <xsl:value-of select="substring-after($keywordstring,$separator)"/>
+                    </xsl:variable>
+                    <xsl:element name="dif:Term">
+                        <xsl:choose>
+                            <xsl:when test="contains($tmpstr1,$separator)">
+                                <xsl:value-of select="substring-before($tmpstr1,$separator)"/>
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <xsl:value-of select="$tmpstr1"/>
+                            </xsl:otherwise>
+                        </xsl:choose>
+                    </xsl:element>
+                    <xsl:variable name="tmpstr2">
+                        <xsl:value-of select="substring-after($tmpstr1,$separator)"/>
+                    </xsl:variable>
+                    <xsl:element name="dif:Variable_Level_1">
+                        <xsl:choose>
+                            <xsl:when test="contains($tmpstr2,$separator)">
+                                <xsl:value-of select="substring-before($tmpstr2,$separator)"/>
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <xsl:value-of select="$tmpstr2"/>
+                            </xsl:otherwise>
+                        </xsl:choose>
+                    </xsl:element>
+                    <xsl:variable name="tmpstr3">
+                        <xsl:value-of select="substring-after($tmpstr2,$separator)"/>
+                    </xsl:variable>
+                    <xsl:element name="dif:Variable_Level_2">
+                        <xsl:choose>
+                            <xsl:when test="contains($tmpstr3,$separator)">
+                                <xsl:value-of select="substring-before($tmpstr3,$separator)"/>
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <xsl:value-of select="$tmpstr3"/>
+                            </xsl:otherwise>
+                        </xsl:choose>
+                    </xsl:element>
+                </xsl:when>
+            </xsl:choose>
+        </xsl:template>
+
+        <xsl:template match="mmd:keywords[@vocabulary = 'GCMDLOC']">
+            <xsl:for-each select="mmd:keyword">
+                <xsl:element name="dif:Location">
+                    <xsl:variable name="mykeywordstringloc">
+                        <xsl:value-of select="."/>
+                    </xsl:variable>
+                    <xsl:call-template name="keywordseparationloc">
+                        <xsl:with-param name="keywordstringloc" select="(translate($mykeywordstringloc, 'abcdefghijklmnopqrstuvwxyz', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'))" />
+                    </xsl:call-template>
+                </xsl:element>
+            </xsl:for-each>
+        </xsl:template>
+        <!-- Template to split keywords into the sub elements DIF require -->
+        <xsl:variable name="separatorloc">
+            <xsl:text> &gt; </xsl:text>
+        </xsl:variable>
+        <xsl:template name="keywordseparationloc">
+            <xsl:param name="keywordstringloc"/>
+            <xsl:choose>
+                <xsl:when test="contains($keywordstringloc,$separatorloc)">
+                    <xsl:element name="dif:Location_Category">
+                        <xsl:value-of select="substring-before($keywordstringloc,$separatorloc)"/>
+                    </xsl:element>
+                    <xsl:variable name="tmpstr1">
+                        <xsl:value-of select="substring-after($keywordstringloc,$separatorloc)"/>
+                    </xsl:variable>
+                    <xsl:element name="dif:Location_Type">
+                        <xsl:choose>
+                            <xsl:when test="contains($tmpstr1,$separator)">
+                                <xsl:value-of select="substring-before($tmpstr1,$separatorloc)"/>
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <xsl:value-of select="$tmpstr1"/>
+                            </xsl:otherwise>
+                        </xsl:choose>
+                    </xsl:element>
+                    <xsl:variable name="tmpstr2">
+                        <xsl:value-of select="substring-after($tmpstr1,$separatorloc)"/>
+                    </xsl:variable>
+                    <xsl:element name="dif:Location_Subregion1">
+                        <xsl:choose>
+                            <xsl:when test="contains($tmpstr2,$separatorloc)">
+                                <xsl:value-of select="substring-before($tmpstr2,$separatorloc)"/>
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <xsl:value-of select="$tmpstr2"/>
+                            </xsl:otherwise>
+                        </xsl:choose>
+                    </xsl:element>
+                    <xsl:variable name="tmpstr3">
+                        <xsl:value-of select="substring-after($tmpstr2,$separatorloc)"/>
+                    </xsl:variable>
+                    <xsl:element name="dif:Location_Subregion2">
+                        <xsl:choose>
+                            <xsl:when test="contains($tmpstr3,$separator)">
+                                <xsl:value-of select="substring-before($tmpstr3,$separatorloc)"/>
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <xsl:value-of select="$tmpstr3"/>
+                            </xsl:otherwise>
+                        </xsl:choose>
+                    </xsl:element>
+                    <xsl:variable name="tmpstr4">
+                        <xsl:value-of select="substring-after($tmpstr3,$separatorloc)"/>
+                    </xsl:variable>
+                    <xsl:element name="dif:Location_Subregion3">
+                        <xsl:choose>
+                            <xsl:when test="contains($tmpstr4,$separatorloc)">
+                                <xsl:value-of select="substring-before($tmpstr4,$separatorloc)"/>
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <xsl:value-of select="$tmpstr4"/>
+                            </xsl:otherwise>
+                        </xsl:choose>
+                    </xsl:element>
+                    <xsl:variable name="tmpstr5">
+                        <xsl:value-of select="substring-after($tmpstr4,$separatorloc)"/>
+                    </xsl:variable>
+                    <xsl:element name="dif:Detailed_Location">
+                        <xsl:choose>
+                            <xsl:when test="contains($tmpstr5,$separatorloc)">
+                                <xsl:value-of select="substring-before($tmpstr5,$separatorloc)"/>
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <xsl:value-of select="$tmpstr5"/>
+                            </xsl:otherwise>
+                        </xsl:choose>
+                    </xsl:element>
+                </xsl:when>
+            </xsl:choose>
+        </xsl:template>
+
 
 	<xsl:template match="mmd:temporal_extent">
 		<xsl:element name="dif:Temporal_Coverage">
-			<xsl:element name="dif:Start_Date">
+		    <xsl:element name="dif:Range_DateTime">
+			<xsl:element name="dif:Beginning_Date_Time">
 				<xsl:value-of select="mmd:start_date" />
 			</xsl:element>
-			<xsl:element name="dif:_Date">
-				<xsl:value-of select="mmd:end_date" />
+			<xsl:element name="dif:Ending_Date_Time">
+			    <xsl:choose>
+				<xsl:when test="mmd:end_date !=''">
+				    <xsl:value-of select="mmd:end_date" />
+				</xsl:when>
+				<xsl:otherwise>
+				    <xsl:text>unbounded</xsl:text>
+				</xsl:otherwise>
+			    </xsl:choose>
 			</xsl:element>
+		    </xsl:element>
 		</xsl:element>
 	</xsl:template>
 
 	<xsl:template match="mmd:geographic_extent/mmd:rectangle">
 		<xsl:element name="dif:Spatial_Coverage">
-			<xsl:element name="dif:Southernmost_Latitude">
+		    <xsl:element name="dif:Granule_Spatial_Representation">
+			<xsl:text>CARTESIAN</xsl:text>
+		    </xsl:element>
+		    <xsl:element name="dif:Geometry">
+		        <xsl:element name="dif:Coordinate_System">
+			    <xsl:text>CARTESIAN</xsl:text>
+		        </xsl:element>
+		        <xsl:element name="dif:Bounding_Rectangle">
+			    <xsl:element name="dif:Southernmost_Latitude">
 				<xsl:value-of select="mmd:south" />
-			</xsl:element>
-			<xsl:element name="dif:Northernmost_Latitude">
+			    </xsl:element>
+			    <xsl:element name="dif:Northernmost_Latitude">
 				<xsl:value-of select="mmd:north" />
-			</xsl:element>
-			<xsl:element name="dif:Westernmost_Longitude">
+			    </xsl:element>
+			    <xsl:element name="dif:Westernmost_Longitude">
 				<xsl:value-of select="mmd:west" />
-			</xsl:element>
-			<xsl:element name="dif:Easternmost_Longitude">
+			    </xsl:element>
+			    <xsl:element name="dif:Easternmost_Longitude">
 				<xsl:value-of select="mmd:east" />
+			    </xsl:element>
 			</xsl:element>
+		    </xsl:element>
 		</xsl:element>
 	</xsl:template>
 
 	<xsl:template match="mmd:data_access">
 		<xsl:element name="dif:Related_URL">
-			<xsl:element name="dif:URL_Content_Type">
-				<xsl:element name="dif:Type">
-					<xsl:value-of select="mmd:type" />
-				</xsl:element>
-			</xsl:element>
-			<xsl:element name="dif:URL">
-				<xsl:value-of select="mmd:resource" />
-			</xsl:element>
-			<xsl:element name="dif:Description">
-				<xsl:value-of select="mmd:description" />
-			</xsl:element>
-		</xsl:element>
+		    <xsl:element name="dif:URL_Content_Type">
+			<xsl:if test="mmd:type = 'HTTP'">
+			    <xsl:element name="dif:Type">
+			        <xsl:text>GET DATA</xsl:text>
+			    </xsl:element>
+			    <xsl:element name="dif:Subtype">
+			        <xsl:text>DIRECT DOWNLOAD</xsl:text>
+			    </xsl:element>
+			</xsl:if>
+			<xsl:if test="mmd:type = 'OPeNDAP'">
+			    <xsl:element name="dif:Type">
+			        <xsl:text>USE SERVICE API</xsl:text>
+			    </xsl:element>
+			    <xsl:element name="dif:Subtype">
+			        <xsl:text>OPENDAP DATA</xsl:text>
+			    </xsl:element>
+			</xsl:if>
+			<xsl:if test="mmd:type = 'OGC WMS'">
+			    <xsl:element name="dif:Type">
+			        <xsl:text>USE SERVICE API</xsl:text>
+			    </xsl:element>
+			    <xsl:element name="dif:Subtype">
+			        <xsl:text>WEB MAP SERVICE (WMS)</xsl:text>
+			    </xsl:element>
+			</xsl:if>
+			<xsl:if test="mmd:type = 'OGC WFS'">
+			    <xsl:element name="dif:Type">
+			        <xsl:text>USE SERVICE API</xsl:text>
+			    </xsl:element>
+			    <xsl:element name="dif:Subtype">
+			        <xsl:text>WEB FEATURE SERVICE (WFS)</xsl:text>
+			    </xsl:element>
+			</xsl:if>
+			<xsl:if test="mmd:type = 'OGC WCS'">
+			    <xsl:element name="dif:Type">
+			        <xsl:text>USE SERVICE API</xsl:text>
+			    </xsl:element>
+			    <xsl:element name="dif:Subtype">
+			        <xsl:text>WEB COVERAGE SERVICE (WCS)</xsl:text>
+			    </xsl:element>
+			</xsl:if>
+			<xsl:if test="mmd:type = 'FTP'">
+			    <xsl:element name="dif:Type">
+			        <xsl:text>GET DATA</xsl:text>
+			    </xsl:element>
+			    <xsl:element name="dif:Subtype">
+			        <xsl:text>DIRECT DOWNLOAD</xsl:text>
+			    </xsl:element>
+			</xsl:if>
+		   </xsl:element>
+		   <xsl:element name="dif:URL">
+		       <xsl:value-of select="mmd:resource" />
+		   </xsl:element>
+		   <xsl:element name="dif:Description">
+		       <xsl:value-of select="mmd:description" />
+	           </xsl:element>
+	    </xsl:element>
 	</xsl:template>
 
 	<xsl:template match="mmd:project">
@@ -125,50 +527,74 @@
 		</xsl:element>
 	</xsl:template>
 
-	<xsl:template match="mmd:instrument">
-		<xsl:element name="dif:Instrument">
-			<xsl:element name="dif:Short_Name">
-				<xsl:value-of select="mmd:short_name" />
-			</xsl:element>
-			<xsl:element name="dif:Long_Name">
-				<xsl:value-of select="mmd:long_name" />
-			</xsl:element>
+	<xsl:template match="mmd:quality_control">
+		<xsl:element name="dif:Quality">
+			<xsl:value-of select="." />
 		</xsl:element>
 	</xsl:template>
 
 	<xsl:template match="mmd:platform">
 		<xsl:element name="dif:Platform">
+			<xsl:element name="dif:Type">
+				<xsl:text>Not provided</xsl:text>
+			</xsl:element>
 			<xsl:element name="dif:Short_Name">
 				<xsl:value-of select="mmd:short_name" />
 			</xsl:element>
 			<xsl:element name="dif:Long_Name">
 				<xsl:value-of select="mmd:long_name" />
+			</xsl:element>
+			<xsl:element name="dif:Instrument">
+			    <xsl:element name="dif:Short_Name">
+				<xsl:value-of select="mmd:instrument/mmd:short_name" />
+			    </xsl:element>
+			    <xsl:element name="dif:Long_Name">
+				<xsl:value-of select="mmd:instrument/mmd:long_name" />
+			    </xsl:element>
 			</xsl:element>
 		</xsl:element>
 	</xsl:template>
 
 	<xsl:template match="mmd:access_constraint">
 		<xsl:element name="dif:Access_Constraints">
+		    <xsl:element name="dif:Description">
 			<xsl:value-of select="." />
+		    </xsl:element>
 		</xsl:element>
 	</xsl:template>
 
 	<xsl:template match="mmd:use_constraint">
 		<xsl:element name="dif:Use_Constraints">
-			<xsl:value-of select="mmd:identifier" />
+			<xsl:choose>
+			    <xsl:when test="mmd:license_text">
+		                <xsl:element name="dif:License_Text">
+			            <xsl:value-of select="mmd:license_text" />
+		                </xsl:element>
+			    </xsl:when>
+			    <xsl:otherwise>
+		                <xsl:element name="dif:License_URL">
+		                    <xsl:element name="dif:URL">
+			                <xsl:value-of select="mmd:resource" />
+		                    </xsl:element>
+		                </xsl:element>
+			    </xsl:otherwise>
+			</xsl:choose>
 		</xsl:element>
 	</xsl:template>
 
 	<xsl:template match="mmd:dataset_production_status">
-		<xsl:element name="dif:Data_Set_Progress">
-			<!--TODO: Fix proper translation of status -->
-			<xsl:value-of select="." />
+		<xsl:element name="dif:Dataset_Progress">
+                    <xsl:variable name="mmd_status" select="normalize-space(.)" />
+                    <xsl:variable name="mmd_status_mapping" select="document('')/*/mapping:dataset_status[@mmd=$mmd_status]/@dif" />
+                    <xsl:value-of select="$mmd_status_mapping" />
 		</xsl:element>
 	</xsl:template>
 
 	<xsl:template match="mmd:dataset_language">
-		<xsl:element name="dif:Data_Set_Language">
-			<xsl:value-of select="." />
+		<xsl:element name="dif:Dataset_Language">
+                    <xsl:variable name="mmd_language" select="normalize-space(.)" />
+                    <xsl:variable name="mmd_language_mapping" select="document('')/*/mapping:language[@mmd=$mmd_language]/@dif" />
+                    <xsl:value-of select="$mmd_language_mapping" />
 		</xsl:element>
 	</xsl:template>
 
@@ -178,10 +604,21 @@
 		</xsl:element>
 	</xsl:template>
 
+        <xsl:template match="mmd:keywords">
+            <xsl:for-each select="mmd:keyword">
+                <xsl:element name="dif:Ancillary_Keyword">
+                    <xsl:value-of select="."/>
+                </xsl:element>
+            </xsl:for-each>
+        </xsl:template>
+
 	<xsl:template match="mmd:data_center">
 
-		<xsl:element name="dif:Data_Center">
-			<xsl:element name="dif:Data_Center_Name">
+		<xsl:element name="dif:Organization">
+			<xsl:element name="dif:Organization_Type">
+			    <xsl:text>DISTRIBUTOR</xsl:text>
+			</xsl:element>
+			<xsl:element name="dif:Organization_Name">
 				<xsl:element name="dif:Short_Name">
 					<xsl:value-of select="mmd:data_center_name/mmd:short_name" />
 				</xsl:element>
@@ -189,47 +626,45 @@
 					<xsl:value-of select="mmd:data_center_name/mmd:long_name" />
 				</xsl:element>
 			</xsl:element>
-			<xsl:element name="dif:Data_Center_URL">
+			<xsl:element name="dif:Organization_URL">
 				<xsl:value-of select="mmd:data_center_url" />
 			</xsl:element>
-			<!--TODO: Fix when alternate_identifier has been defined
-			<xsl:element name="dif:Data_Set_ID">
-				<xsl:value-of select="mmd:dataset_id" />
-			</xsl:element-->
-			<xsl:element name="dif:Personel">
-				<xsl:element name="dif:Role">
-					<xsl:value-of select="mmd:personnel/mmd:role"></xsl:value-of>
-				</xsl:element>
-				<xsl:element name="dif:First_Name" />
-				<xsl:element name="dif:Middle_Name" />
-				<xsl:element name="dif:Last_Name">
-					<xsl:value-of select="mmd:personnel/mmd:name"></xsl:value-of>
-				</xsl:element>
-				<xsl:element name="dif:Phone">
-					<xsl:value-of select="mmd:personnel/mmd:phone"></xsl:value-of>
-				</xsl:element>
-				<xsl:element name="dif:Fax">
-					<xsl:value-of select="mmd:personnel/mmd:fax"></xsl:value-of>
-				</xsl:element>
-
-				<xsl:element name="dif:Contact_Address">
-					<xsl:element name="dif:Address">
-						<xsl:value-of select="mmd:personnel/mmd:contact_address/mmd:address" />
-					</xsl:element>
-					<xsl:element name="dif:City">
-						<xsl:value-of select="mmd:personnel/mmd:contact_address/mmd:city" />
-					</xsl:element>
-					<xsl:element name="dif:Province_or_State">
-						<xsl:value-of
-							select="mmd:personnel/mmd:contact_address/mmd:province_or_state" />
-					</xsl:element>
-					<xsl:element name="dif:Postal_Code">
-						<xsl:value-of select="mmd:personnel/mmd:contact_address/mmd:postal_code" />
-					</xsl:element>
-					<xsl:element name="dif:country">
-						<xsl:value-of select="mmd:personnel/mmd:contact_address/mmd:country" />
-					</xsl:element>
-				</xsl:element>
+			<xsl:element name="dif:Personnel">
+                            <xsl:element name="dif:Role">
+				    <xsl:text>DATA CENTER CONTACT</xsl:text>
+                            </xsl:element>
+                            <xsl:element name="dif:Contact_Group">
+                                <xsl:element name="dif:Name">
+		                    <xsl:value-of select="../mmd:personnel/mmd:name[../mmd:role='Data center contact']" />
+                                </xsl:element>
+				<xsl:if test="../mmd:personnel/mmd:phone[../mmd:role='Data center contact']">
+				    <xsl:element name="dif:Phone">
+				       <xsl:element name="dif:Number">
+		                           <xsl:value-of select="../mmd:personnel/mmd:phone[../mmd:role='Data center contact']" />
+                                       </xsl:element>
+				       <xsl:element name="dif:Type">
+				           <xsl:text>Telephone</xsl:text>
+                                       </xsl:element>
+                                    </xsl:element>
+                                </xsl:if>
+                                <!--xsl:element name="dif:Address">
+                                    <xsl:element name="dif:Address">
+		                        <xsl:value-of select="../mmd:personnel/mmd:contact_address/mmd:address[../../mmd:role='Data center contact']" />
+                                    </xsl:element>
+                                    <xsl:element name="dif:City">
+		                        <xsl:value-of select="../mmd:personnel/mmd:contact_address/mmd:city[../../mmd:role='Data center contact']" />
+                                    </xsl:element>
+                                    <xsl:element name="dif:Province_or_State">
+                                        <xsl:value-of select="../mmd:personnel/mmd:contact_address/mmd:province_or_state[../../mmd:role='Data center contact']" />
+                                    </xsl:element>
+                                    <xsl:element name="dif:Postal_Code">
+		                        <xsl:value-of select="../mmd:personnel/mmd:contact_address/mmd:postal_code[../../mmd:role='Data center contact']" />
+                                    </xsl:element>
+                                    <xsl:element name="dif:Country">
+		                        <xsl:value-of select="../mmd:personnel/mmd:contact_address/mmd:country[../../mmd:role='Data center contact']" />
+                                    </xsl:element>
+                                </xsl:element-->
+			    </xsl:element>
 			</xsl:element>
 		</xsl:element>
 	</xsl:template>
@@ -237,40 +672,93 @@
 
     <xsl:template match="mmd:dataset_citation">
 
-        <xsl:element name="dif:Data_Set_Citation">
+        <xsl:element name="dif:Dataset_Citation">
             <xsl:element name="dif:Dataset_Creator">
-                <xsl:value-of select="mmd:dataset_creator" />
-            </xsl:element>
-            <xsl:element name="dif:Dataset_Editor">
-                <xsl:value-of select="mmd:dataset_editor" />
+                <xsl:value-of select="mmd:author" />
             </xsl:element>
             <xsl:element name="dif:Dataset_Title">
-                <xsl:value-of select="mmd:dataset_title" />
+                <xsl:value-of select="mmd:title" />
             </xsl:element>
             <xsl:element name="dif:Dataset_Series_Name">
-                <xsl:value-of select="mmd:dataset_series_name" />
+                <xsl:value-of select="mmd:series" />
             </xsl:element>
             <xsl:element name="dif:Dataset_Release_Date">
-                <xsl:value-of select="mmd:dataset_release_date" />
+                <xsl:value-of select="mmd:publication_date" />
             </xsl:element>
             <xsl:element name="dif:Dataset_Release_Place">
-                <xsl:value-of select="mmd:dataset_release_place" />
+                <xsl:value-of select="mmd:publication_place" />
             </xsl:element>
             <xsl:element name="dif:Dataset_Publisher">
-                <xsl:value-of select="mmd:dataset_publisher" />
+                <xsl:value-of select="mmd:publisher" />
             </xsl:element>
             <xsl:element name="dif:Version">
-                <xsl:value-of select="mmd:version" />
+                <xsl:value-of select="mmd:edition" />
             </xsl:element>
-            <xsl:element name="dif:Data_Presentation_Form">
-                <xsl:value-of select="mmd:dataset_presentation_form" />
+            <xsl:element name="dif:Other_Citation_Details">
+                <xsl:value-of select="mmd:other" />
             </xsl:element>
+	    <xsl:if test="mmd:doi !=''">
+            <xsl:element name="dif:Persistent_Identifier">
+                <xsl:element name="dif:Type">
+	            <xsl:text>DOI</xsl:text>
+                </xsl:element>
+                <xsl:element name="dif:Identifier">
+                    <xsl:value-of select="substring-after(mmd:doi, 'https://doi.org/')" />
+                </xsl:element>
+                <xsl:element name="dif:Authority">
+	            <xsl:text>https://doi.org/</xsl:text>
+                </xsl:element>
+            </xsl:element>
+            </xsl:if>
             <xsl:element name="dif:Online_Resource">
-                <xsl:value-of select="mmd:online_resource" />
+                <xsl:value-of select="mmd:url" />
             </xsl:element>
 
         </xsl:element>
 
+
     </xsl:template>
 
+    <xsl:template match="mmd:personnel">
+        <xsl:element name="dif:Personnel">
+            <xsl:element name="dif:Role">
+                <xsl:value-of select="translate(mmd:role,'abcdefghijklmnopqrstuvwxyz','ABCDEFGHIJKLMNOPQRSTUVWXYZ')" />
+            </xsl:element>
+            <xsl:element name="dif:Contact_Group">
+                <xsl:element name="dif:Name">
+                    <xsl:value-of select="mmd:name" />
+                </xsl:element>
+                <xsl:element name="dif:Address">
+                    <xsl:element name="dif:Street_Address">
+			<xsl:value-of select="mmd:contact_address/mmd:address" />
+                    </xsl:element>
+                    <xsl:element name="dif:City">
+			<xsl:value-of select="mmd:contact_address/mmd:city" />
+                    </xsl:element>
+                    <xsl:element name="dif:State_Province">
+			<xsl:value-of select="mmd:contact_address/mmd:province_or_state" />
+                    </xsl:element>
+                    <xsl:element name="dif:Postal_Code">
+			<xsl:value-of select="mmd:contact_address/mmd:postal_code" />
+                    </xsl:element>
+                    <xsl:element name="dif:Country">
+			<xsl:value-of select="mmd:contact_address/mmd:country" />
+                    </xsl:element>
+                </xsl:element>
+                <xsl:element name="dif:Email">
+                    <xsl:value-of select="mmd:email" />
+                </xsl:element>
+            </xsl:element>
+        </xsl:element>
+    </xsl:template>
+
+    <!-- Mappings for dataset_production_status -->
+    <mapping:dataset_status dif="COMPLETE" mmd="Complete" />
+    <mapping:dataset_status dif="COMPLETE" mmd="Obsolete" />
+    <mapping:dataset_status dif="IN WORK" mmd="In Work" />
+    <mapping:dataset_status dif="PLANNED" mmd="Planned" />
+    <mapping:dataset_status dif="NOT PROVIDED" mmd="Not available" />
+
+    <mapping:language dif="English" mmd="en" />
+    <mapping:language dif="Norwegian" mmd="no" />
 </xsl:stylesheet>

--- a/xslt/mmd-to-iso.xsl
+++ b/xslt/mmd-to-iso.xsl
@@ -41,7 +41,6 @@
             </gmd:hierarchyLevel>        
 
             <xsl:apply-templates select="mmd:metadata_identifier" />
-            <xsl:apply-templates select="mmd:dataset_production_status" />
             <xsl:element name="gmd:dateStamp">
                 <xsl:element name="gco:DateTime">
 	            <xsl:variable name="latest">
@@ -119,7 +118,12 @@
                     <!-- non-english elements taken care of within template -->
                     <xsl:apply-templates select="mmd:abstract[@xml:lang = 'en']" />
                     
-                    <xsl:apply-templates select="mmd:iso_topic_category" />
+		    <xsl:if test="mmd:dataset_production_status != 'Not available'">
+		        <xsl:apply-templates select="mmd:dataset_production_status" />
+	            </xsl:if>
+		    <xsl:if test="mmd:iso_topic_category != 'Not available'">
+                        <xsl:apply-templates select="mmd:iso_topic_category" />
+	            </xsl:if>
                     
                     <xsl:element name="gmd:pointOfContact">
                         <xsl:apply-templates select="mmd:personnel[mmd:role != 'Metadata author']" />
@@ -336,10 +340,10 @@
 	   <xsl:element name="gmd:title">
               <xsl:element name="gco:CharacterString">
 		 <xsl:choose>
-		     <xsl:when test="@vocabulary = 'CF' or @vocabulary = 'cf' or contains(@vocabulary, 'Climate and Forecast')">
+		     <xsl:when test="@vocabulary = 'CFSTDN' or @vocabulary = 'CF' or @vocabulary = 'cf' or contains(@vocabulary, 'Climate and Forecast')">
 			 <xsl:text>Climate and Forecast (CF) Standard Name Table</xsl:text>
 	             </xsl:when>
-		     <xsl:when test="contains(@vocabulary, 'GCMD') or @vocabulary= 'gcmd' or contains(@vocabulary, 'Global Change Master Directory')">
+		     <xsl:when test="contains(@vocabulary, 'GCMD') or @vocabulary= 'gcmd' or @vocabulary= 'GCMDSK' or contains(@vocabulary, 'Global Change Master Directory')">
 			 <xsl:text>Global Change Master Directory (GCMD)</xsl:text>
 	             </xsl:when>
 		     <xsl:otherwise>

--- a/xslt/mmd-to-iso2.xsl
+++ b/xslt/mmd-to-iso2.xsl
@@ -181,7 +181,9 @@
 		        </xsl:otherwise>
 		    </xsl:choose>
 
-                    <xsl:apply-templates select="mmd:dataset_production_status" />
+		    <xsl:if test="mmd:dataset_production_status != 'Not available'">
+                        <xsl:apply-templates select="mmd:dataset_production_status" />
+	            </xsl:if>
                     
 		    <xsl:for-each select="mmd:personnel[mmd:role != 'Metadata author']">
                         <xsl:element name="gmd:pointOfContact">
@@ -265,7 +267,9 @@
                     </xsl:element>
 
 
-                    <xsl:apply-templates select="mmd:iso_topic_category" />
+		    <xsl:if test="mmd:iso_topic_category != 'Not available'">
+                        <xsl:apply-templates select="mmd:iso_topic_category" />
+	            </xsl:if>
                     
                     <xsl:element name="gmd:extent">
                         <xsl:element name="gmd:EX_Extent">


### PR DESCRIPTION
These are the main changes: 

- doc: added "Not available" for dataset_production_status (updated iso mapping tables), iso_topic_category, operational_status and activity_type. Added "None" for vocabulary attribute.
- thesauri: added "Not available" for the above mentioned entries, with skos note for change.
- mmd.xsd: added values in list.
- dif-to-mmd: added "Not available" if Data_Set_Progress or ISO_Topic_Category are not provided
- ecmwf-iso-to-mmd: added "Not available" if gmd:status and gmd:MD_TopicCategoryCode are not provided. Fix vocabulary attribute from none to None
- iso-to-mmd: added "Not available" if gmd:status and gmd:MD_TopicCategoryCode are not provided. Fix vocabulary attribute from none to None and gcmd to GCMDSK.
- mmd-to-dif: do not map Data_Set_Progress and ISO_Topic_Category for "Not available" (in dif9 they are not mandatory).
- mmd-to-dif10: this was outdated (probably never revised). It has major changes.
- mmd-to-iso: skip mapping for "Not available" dataset_production_status and iso_topic_category, update vocabulary to GCMDSK and CFSTDN
- mmd-to-iso2: skip mapping for "Not available" dataset_production_status and iso_topic_category
