### PR TITLE
Add SIOSIN to collection tag

### DIFF
--- a/doc/ch04-md-contrvocabs.adoc
+++ b/doc/ch04-md-contrvocabs.adoc
@@ -56,6 +56,8 @@ data. This is primarily Sentinel datasets.
 
 |SIOSAP |Datasets from the SIOS Access Programme. 
 
+|SIOSIN |Datasets from the SIOS InfraNor Project.
+
 |CVL |Datasets from the ESA Cryosphere Virtual Lab.
 
 |=======================================================================

--- a/thesauri/mmd-vocabulary.ttl
+++ b/thesauri/mmd-vocabulary.ttl
@@ -839,7 +839,7 @@
   skos:inScheme <https://vocab.met.no/mmd>; 
   skos:prefLabel "Collection Keywords"@en ;
   skos:definition "The purpose of this vocabulary is to identify which collection a dataset belong to. This is used to identify sets when serving metadata through e.g. OAI-PMH or to identify which data to present in e.g. a project specific portal when all metadata records are in the same repository."@en ;
-  skos:member <https://vocab.met.no/mmd/Collection_Keywords/CC>, <https://vocab.met.no/mmd/Collection_Keywords/ADC>, <https://vocab.met.no/mmd/Collection_Keywords/GCW>, <https://vocab.met.no/mmd/Collection_Keywords/NMDC>, <https://vocab.met.no/mmd/Collection_Keywords/SIOS>, <https://vocab.met.no/mmd/Collection_Keywords/NSDN>, <https://vocab.met.no/mmd/Collection_Keywords/DOKI>, <https://vocab.met.no/mmd/Collection_Keywords/DAM>, <https://vocab.met.no/mmd/Collection_Keywords/ACCESS>, <https://vocab.met.no/mmd/Collection_Keywords/NBS>, <https://vocab.met.no/mmd/Collection_Keywords/APPL>, <https://vocab.met.no/mmd/Collection_Keywords/YOPP>, <https://vocab.met.no/mmd/Collection_Keywords/METNCS>, <https://vocab.met.no/mmd/Collection_Keywords/SESS2018>, <https://vocab.met.no/mmd/Collection_Keywords/SESS2019>, <https://vocab.met.no/mmd/Collection_Keywords/SESS2020>, <https://vocab.met.no/mmd/Collection_Keywords/SIOSCD>, <https://vocab.met.no/mmd/Collection_Keywords/SIOSAP>, <https://vocab.met.no/mmd/Collection_Keywords/CVL> .
+  skos:member <https://vocab.met.no/mmd/Collection_Keywords/CC>, <https://vocab.met.no/mmd/Collection_Keywords/ADC>, <https://vocab.met.no/mmd/Collection_Keywords/GCW>, <https://vocab.met.no/mmd/Collection_Keywords/NMDC>, <https://vocab.met.no/mmd/Collection_Keywords/SIOS>, <https://vocab.met.no/mmd/Collection_Keywords/NSDN>, <https://vocab.met.no/mmd/Collection_Keywords/DOKI>, <https://vocab.met.no/mmd/Collection_Keywords/DAM>, <https://vocab.met.no/mmd/Collection_Keywords/ACCESS>, <https://vocab.met.no/mmd/Collection_Keywords/NBS>, <https://vocab.met.no/mmd/Collection_Keywords/APPL>, <https://vocab.met.no/mmd/Collection_Keywords/YOPP>, <https://vocab.met.no/mmd/Collection_Keywords/METNCS>, <https://vocab.met.no/mmd/Collection_Keywords/SESS2018>, <https://vocab.met.no/mmd/Collection_Keywords/SESS2019>, <https://vocab.met.no/mmd/Collection_Keywords/SESS2020>, <https://vocab.met.no/mmd/Collection_Keywords/SIOSCD>, <https://vocab.met.no/mmd/Collection_Keywords/SIOSAP>, <https://vocab.met.no/mmd/Collection_Keywords/SIOSIN>, <https://vocab.met.no/mmd/Collection_Keywords/CVL> .
 
 <https://vocab.met.no/mmd/Collection_Keywords/CC>
   a skos:Concept ;
@@ -936,6 +936,12 @@
   skos:prefLabel "SIOSAP"@en ;
   rdfs:seeAlso <https://sios-svalbard.org/RIAccess> ;
   skos:definition "Datasets from the SIOS Access Programme."@en .
+
+<https://vocab.met.no/mmd/Collection_Keywords/SIOSIN>
+  a skos:Concept ;
+  skos:prefLabel "SIOSIN"@en ;
+  rdfs:seeAlso <https://sios-svalbard.org/InfraNor> ;
+  skos:definition "Datasets from the SIOS InfraNor Project"@en .
 
 <https://vocab.met.no/mmd/Collection_Keywords/CVL>
   a skos:Concept ;

--- a/thesauri/mmd-vocabulary.xml
+++ b/thesauri/mmd-vocabulary.xml
@@ -1246,6 +1246,14 @@
     </skos:member>
 
     <skos:member>
+      <skos:Concept rdf:about="https://vocab.met.no/mmd/Collection_Keywords/SIOSIN">
+        <skos:prefLabel xml:lang="en">SIOSIN</skos:prefLabel>
+        <rdfs:seeAlso rdf:resource="https://sios-svalbard.org/InfraNor"/>
+        <skos:definition xml:lang="en">Datasets from the SIOS InfraNor Project.</skos:definition>
+      </skos:Concept>
+    </skos:member>
+
+    <skos:member>
       <skos:Concept rdf:about="https://vocab.met.no/mmd/Collection_Keywords/CVL">
         <skos:prefLabel xml:lang="en">CVL</skos:prefLabel>
         <skos:definition xml:lang="en">Datasets from the ESA Cryosphere Virtual Lab.</skos:definition>

--- a/xsd/mmd.xsd
+++ b/xsd/mmd.xsd
@@ -421,6 +421,7 @@
             <xs:enumeration value="SESS2020"></xs:enumeration>
             <xs:enumeration value="SIOSCD"></xs:enumeration>
             <xs:enumeration value="SIOSAP"></xs:enumeration>
+            <xs:enumeration value="SIOSIN"></xs:enumeration>
             <xs:enumeration value="CVL"></xs:enumeration>
         </xs:restriction>
     </xs:simpleType>

--- a/xsd/mmd_strict.xsd
+++ b/xsd/mmd_strict.xsd
@@ -441,6 +441,7 @@
             <xs:enumeration value="SESS2020"></xs:enumeration>
             <xs:enumeration value="SIOSCD"></xs:enumeration>
             <xs:enumeration value="SIOSAP"></xs:enumeration>
+            <xs:enumeration value="SIOSIN"></xs:enumeration>
             <xs:enumeration value="CVL"></xs:enumeration>
         </xs:restriction>
     </xs:simpleType>


### PR DESCRIPTION
This is a minor PR to add a missing collection tag for the SIOS InfraNor data. Changes are included in the documentation, the thesauri and the schemas. Closes #190 