### PR TITLE
add AeN collection keyword

### DIFF
--- a/doc/ch04-md-contrvocabs.adoc
+++ b/doc/ch04-md-contrvocabs.adoc
@@ -62,6 +62,8 @@ data. This is primarily Sentinel datasets.
 
 |CVL |Datasets from the ESA Cryosphere Virtual Lab.
 
+|AeN |Datasets from the Arven etter Nansen Project.
+
 |=======================================================================
 
 <<collection>>

--- a/thesauri/mmd-vocabulary.ttl
+++ b/thesauri/mmd-vocabulary.ttl
@@ -1023,7 +1023,7 @@
   skos:inScheme <https://vocab.met.no/mmd>; 
   skos:prefLabel "Collection Keywords"@en ;
   skos:definition "The purpose of this vocabulary is to identify which collection a dataset belong to. This is used to identify sets when serving metadata through e.g. OAI-PMH or to identify which data to present in e.g. a project specific portal when all metadata records are in the same repository."@en ;
-  skos:member <https://vocab.met.no/mmd/Collection_Keywords/CC>, <https://vocab.met.no/mmd/Collection_Keywords/NMAP>, <https://vocab.met.no/mmd/Collection_Keywords/ADC>, <https://vocab.met.no/mmd/Collection_Keywords/GCW>, <https://vocab.met.no/mmd/Collection_Keywords/NMDC>, <https://vocab.met.no/mmd/Collection_Keywords/SIOS>, <https://vocab.met.no/mmd/Collection_Keywords/NSDN>, <https://vocab.met.no/mmd/Collection_Keywords/DOKI>, <https://vocab.met.no/mmd/Collection_Keywords/DAM>, <https://vocab.met.no/mmd/Collection_Keywords/ACCESS>, <https://vocab.met.no/mmd/Collection_Keywords/NBS>, <https://vocab.met.no/mmd/Collection_Keywords/APPL>, <https://vocab.met.no/mmd/Collection_Keywords/YOPP>, <https://vocab.met.no/mmd/Collection_Keywords/METNCS>, <https://vocab.met.no/mmd/Collection_Keywords/SESS2018>, <https://vocab.met.no/mmd/Collection_Keywords/SESS2019>, <https://vocab.met.no/mmd/Collection_Keywords/SESS2020>, <https://vocab.met.no/mmd/Collection_Keywords/SESS2022>, <https://vocab.met.no/mmd/Collection_Keywords/SIOSCD>, <https://vocab.met.no/mmd/Collection_Keywords/SIOSAP>, <https://vocab.met.no/mmd/Collection_Keywords/SIOSIN>, <https://vocab.met.no/mmd/Collection_Keywords/CVL> .
+  skos:member <https://vocab.met.no/mmd/Collection_Keywords/CC>, <https://vocab.met.no/mmd/Collection_Keywords/NMAP>, <https://vocab.met.no/mmd/Collection_Keywords/ADC>, <https://vocab.met.no/mmd/Collection_Keywords/GCW>, <https://vocab.met.no/mmd/Collection_Keywords/NMDC>, <https://vocab.met.no/mmd/Collection_Keywords/SIOS>, <https://vocab.met.no/mmd/Collection_Keywords/NSDN>, <https://vocab.met.no/mmd/Collection_Keywords/DOKI>, <https://vocab.met.no/mmd/Collection_Keywords/DAM>, <https://vocab.met.no/mmd/Collection_Keywords/ACCESS>, <https://vocab.met.no/mmd/Collection_Keywords/NBS>, <https://vocab.met.no/mmd/Collection_Keywords/APPL>, <https://vocab.met.no/mmd/Collection_Keywords/YOPP>, <https://vocab.met.no/mmd/Collection_Keywords/METNCS>, <https://vocab.met.no/mmd/Collection_Keywords/SESS2018>, <https://vocab.met.no/mmd/Collection_Keywords/SESS2019>, <https://vocab.met.no/mmd/Collection_Keywords/SESS2020>, <https://vocab.met.no/mmd/Collection_Keywords/SESS2022>, <https://vocab.met.no/mmd/Collection_Keywords/SIOSCD>, <https://vocab.met.no/mmd/Collection_Keywords/SIOSAP>, <https://vocab.met.no/mmd/Collection_Keywords/SIOSIN>, <https://vocab.met.no/mmd/Collection_Keywords/CVL>, <https://vocab.met.no/mmd/Collection_Keywords/AeN> .
 
 <https://vocab.met.no/mmd/Collection_Keywords/CC>
   a skos:Concept ;
@@ -1142,6 +1142,12 @@
   a skos:Concept ;
   skos:prefLabel "CVL"@en ;
   skos:definition "Datasets from the ESA Cryosphere Virtual Lab."@en .
+
+<https://vocab.met.no/mmd/Collection_Keywords/AeN>
+  a skos:Concept ;
+  skos:prefLabel "AeN"@en ;
+  rdfs:seeAlso <https://arvenetternansen.com/> ; 
+  skos:definition "Datasets from the Arven etter Nansen Project."@en .
 
 
 <https://vocab.met.no/mmd/Instrument_Modes>

--- a/thesauri/mmd-vocabulary.xml
+++ b/thesauri/mmd-vocabulary.xml
@@ -1512,6 +1512,14 @@
       </skos:Concept>
     </skos:member>
 
+    <skos:member>
+      <skos:Concept rdf:about="https://vocab.met.no/mmd/Collection_Keywords/AeN">
+        <skos:prefLabel xml:lang="en">AeN</skos:prefLabel>
+        <rdfs:seeAlso rdf:resource="https://arvenetternansen.com/"/>
+        <skos:definition xml:lang="en">Datasets from the Arven etter Nansen Project.</skos:definition>
+      </skos:Concept>
+    </skos:member>
+
   </skos:Collection>
 
   <skos:Collection rdf:about="https://vocab.met.no/mmd/Instrument_Modes">

--- a/xsd/mmd.xsd
+++ b/xsd/mmd.xsd
@@ -424,6 +424,7 @@
             <xs:enumeration value="SIOSAP"></xs:enumeration>
             <xs:enumeration value="SIOSIN"></xs:enumeration>
             <xs:enumeration value="CVL"></xs:enumeration>
+            <xs:enumeration value="AeN"></xs:enumeration>
         </xs:restriction>
     </xs:simpleType>
 

--- a/xsd/mmd_strict.xsd
+++ b/xsd/mmd_strict.xsd
@@ -443,6 +443,7 @@
             <xs:enumeration value="SIOSAP"></xs:enumeration>
             <xs:enumeration value="SIOSIN"></xs:enumeration>
             <xs:enumeration value="CVL"></xs:enumeration>
+            <xs:enumeration value="AeN"></xs:enumeration>
         </xs:restriction>
     </xs:simpleType>
 


### PR DESCRIPTION
AeN was missing from the documentation and controlled vocabularies. close #211 