### PR TITLE
Make data_access and storage_information mandatory in mmd_strict.xsd

### DIFF
--- a/xsd/mmd_strict.xsd
+++ b/xsd/mmd_strict.xsd
@@ -59,10 +59,10 @@
                 <xs:element name="personnel" type="mmd:personnel_type" maxOccurs="unbounded" minOccurs="1"></xs:element>
                 <xs:element name="dataset_citation" type="mmd:dataset_citation_type" maxOccurs="unbounded" minOccurs="0"></xs:element>
                 <xs:element name="quality_control" type="mmd:quality_control_type" maxOccurs="1" minOccurs="0"></xs:element>
-                <xs:element name="data_access" type="mmd:data_access_type" maxOccurs="unbounded" minOccurs="0"></xs:element>
+                <xs:element name="data_access" type="mmd:data_access_type" maxOccurs="unbounded" minOccurs="1"></xs:element>
                 <xs:element name="data_center" type="mmd:data_center_type" maxOccurs="1" minOccurs="0"></xs:element>
                 <xs:element name="related_dataset" type="mmd:related_dataset_type" maxOccurs="unbounded" minOccurs="0"/>
-                <xs:element name="storage_information" type="mmd:storage_information_type" maxOccurs="1" minOccurs="0" />
+                <xs:element name="storage_information" type="mmd:storage_information_type" maxOccurs="1" minOccurs="1" />
             </xs:choice>
         </xs:sequence>
     </xs:complexType>
@@ -330,7 +330,7 @@
             <xs:element name="name" type="xs:string" minOccurs="0"></xs:element>
             <xs:element name="type" type="mmd:data_access_type_type" minOccurs="1" maxOccurs="1"></xs:element>
             <xs:element name="description" type="xs:string" minOccurs="0"></xs:element>
-            <xs:element name="resource" type="xs:string"></xs:element>
+            <xs:element name="resource" type="xs:string" minOccurs="1" maxOccurs="1"></xs:element>
             <xs:element name="wms_layers" type="mmd:wms_layers_type" minOccurs="0" maxOccurs="1"></xs:element>
         </xs:sequence>
     </xs:complexType>
@@ -464,8 +464,8 @@
 
     <xs:complexType name="storage_information_type">
         <xs:sequence>
-            <xs:element name="file_name" type="xs:string" maxOccurs="1" minOccurs="0"></xs:element>
-            <xs:element name="file_location" type="xs:string" maxOccurs="1" minOccurs="0"></xs:element>
+            <xs:element name="file_name" type="xs:string" maxOccurs="1" minOccurs="1"></xs:element>
+            <xs:element name="file_location" type="xs:string" maxOccurs="1" minOccurs="1"></xs:element>
             <xs:element name="file_format" type="xs:string" maxOccurs="1" minOccurs="0"></xs:element>
             <xs:element name="file_size" type="mmd:value_size"  maxOccurs="1" minOccurs="0"></xs:element>
             <xs:element name="checksum" type="mmd:value_checksum"  maxOccurs="1" minOccurs="0"></xs:element>


### PR DESCRIPTION
     Closes #
     - Made 'data_access' and 'storage_information' mandatory
     - Made 'resource' in 'data_access_type' mandatory
     - Made 'file_name' and 'file_location' in 'storage_information_type' mandatory