### PR TITLE
add spatial representation in thesauri, update xslt to genorge

### DIFF
--- a/thesauri/mmd-vocabulary.ttl
+++ b/thesauri/mmd-vocabulary.ttl
@@ -91,6 +91,35 @@
   skos:prefLabel "None"@en ;
   skos:definition "This tag should be used to provide keywords that do not belong to a controlled vocabulary."@en .
 
+<https://vocab.met.no/mmd/Spatial_Representation>
+  a skos:Collection, isothes:ConceptGroup ;
+  skos:inScheme <https://vocab.met.no/mmd>;
+  skos:prefLabel "Spatial Representation"@en ;
+  skos:definition "The method used to spatially represent geographic information."@en ;
+  skos:member <https://vocab.met.no/mmd/Spatial_Representation/vector>, <https://vocab.met.no/mmd/Spatial_Representation/grid>, <https://vocab.met.no/mmd/Spatial_Representation/point>, <https://vocab.met.no/mmd/Spatial_Representation/trajectory> .
+
+<https://vocab.met.no/mmd/Spatial_Representation/vector>
+  a skos:Concept ;
+  skos:prefLabel "vector"@en ;
+  skos:exactMatch <http://inspire.ec.europa.eu/metadata-codelist/SpatialRepresentationType/vector> ;
+  skos:definition "Vector data is used to represent geographic data."@en .
+
+<https://vocab.met.no/mmd/Spatial_Representation/grid>
+  a skos:Concept ;
+  skos:prefLabel "grid"@en ;
+  skos:exactMatch <http://inspire.ec.europa.eu/metadata-codelist/SpatialRepresentationType/grid> ;
+  skos:definition "Grid data is used to represent geographic data."@en .
+
+<https://vocab.met.no/mmd/Spatial_Representation/point>
+  a skos:Concept ;
+  skos:prefLabel "point"@en ;
+  skos:definition "A single data point (having no implied coordinate relationship to other points)"@en .
+
+<https://vocab.met.no/mmd/Spatial_Representation/trajectory>
+  a skos:Concept ;
+  skos:prefLabel "trajectory"@en ;
+  skos:definition "A series of data points along a path through space with monotonically increasing times"@en .
+
 <https://vocab.met.no/mmd/Use_Constraint>
   a skos:Collection, isothes:ConceptGroup ;
   skos:inScheme <https://vocab.met.no/mmd>; 

--- a/thesauri/mmd-vocabulary.xml
+++ b/thesauri/mmd-vocabulary.xml
@@ -116,6 +116,43 @@
 
   </skos:Collection>
 
+  <skos:Collection rdf:about="https://vocab.met.no/mmd/Spatial_Representation">
+    <rdf:type rdf:resource="http://purl.org/iso25964/skos-thes#ConceptGroup"/>
+    <skos:inScheme rdf:resource="https://vocab.met.no/mmd"/>
+    <skos:prefLabel xml:lang="en">Spatial Representation</skos:prefLabel>
+    <skos:definition xml:lang="en">The method used to spatially represent geographic information.</skos:definition>
+    <skos:member>
+      <skos:Concept rdf:about="https://vocab.met.no/mmd/Spatial_Representation/vector">
+        <skos:prefLabel xml:lang="en">vector</skos:prefLabel>
+        <skos:definition xml:lang="en">Vector data is used to represent geographic data.</skos:definition>
+        <skos:exactMatch rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialRepresentationType/vector"/>
+      </skos:Concept>
+    </skos:member>
+
+    <skos:member>
+      <skos:Concept rdf:about="https://vocab.met.no/mmd/Spatial_Representation/grid">
+        <skos:prefLabel xml:lang="en">grid</skos:prefLabel>
+        <skos:definition xml:lang="en">Grid data is used to represent geographic data.</skos:definition>
+        <skos:exactMatch rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialRepresentationType/grid"/>
+      </skos:Concept>
+    </skos:member>
+
+    <skos:member>
+      <skos:Concept rdf:about="https://vocab.met.no/mmd/Spatial_Representation/point">
+        <skos:prefLabel xml:lang="en">point</skos:prefLabel>
+        <skos:definition xml:lang="en">A single data point (having no implied coordinate relationship to other points)</skos:definition>
+      </skos:Concept>
+    </skos:member>
+
+    <skos:member>
+      <skos:Concept rdf:about="https://vocab.met.no/mmd/Spatial_Representation/trajectory">
+        <skos:prefLabel xml:lang="en">trajectory</skos:prefLabel>
+        <skos:definition xml:lang="en">A series of data points along a path through space with monotonically increasing times</skos:definition>
+      </skos:Concept>
+    </skos:member>
+
+  </skos:Collection>
+
   <skos:Collection rdf:about="https://vocab.met.no/mmd/Use_Constraint">
     <rdf:type rdf:resource="http://purl.org/iso25964/skos-thes#ConceptGroup"/>
     <skos:inScheme rdf:resource="https://vocab.met.no/mmd"/>

--- a/xslt/mmd-to-geonorge.xsl
+++ b/xslt/mmd-to-geonorge.xsl
@@ -207,15 +207,17 @@
 		    <!--use_constraints (M) multiplicity [1..*] -->
                     <xsl:apply-templates select="mmd:use_constraint" />
 
-		    <xsl:element name="gmd:spatialRepresentationType">
-		        <xsl:element name="gmd:MD_SpatialRepresentationTypeCode">
-			    <xsl:attribute name="codeList">http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_SpatialRepresentationTypeCode</xsl:attribute>
-			    <xsl:attribute name="codeListValue">
-                                <xsl:value-of select="mmd:spatial_representation" />
-			    </xsl:attribute>
-                                <xsl:value-of select="mmd:spatial_representation" />
+		    <xsl:if test="mmd:spatial_representation = 'grid' or mmd:spatial_representation = 'vector'">
+		        <xsl:element name="gmd:spatialRepresentationType">
+		            <xsl:element name="gmd:MD_SpatialRepresentationTypeCode">
+		                <xsl:attribute name="codeList">http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_SpatialRepresentationTypeCode</xsl:attribute>
+		                <xsl:attribute name="codeListValue">
+                                    <xsl:value-of select="mmd:spatial_representation" />
+		                </xsl:attribute>
+                                    <xsl:value-of select="mmd:spatial_representation" />
+		            </xsl:element>
 		        </xsl:element>
-		    </xsl:element>
+		    </xsl:if>
 
 		    <xsl:element name="gmd:language">
 		        <xsl:element name="gmd:LanguageCode">
@@ -824,9 +826,18 @@
                 <xsl:element name="gmd:date">
                     <xsl:choose>
                         <xsl:when test=". !='' ">
-                            <xsl:element name="gco:Date">
-                                <xsl:value-of select="." />
-                            </xsl:element>
+			    <xsl:choose>
+			        <xsl:when test="contains(.,'T')">
+                                    <xsl:element name="gco:Date">
+                                        <xsl:value-of select="substring-before(.,'T')" />
+                                    </xsl:element>
+				</xsl:when>
+				<xsl:otherwise>
+                                    <xsl:element name="gco:Date">
+                                        <xsl:value-of select="." />
+                                    </xsl:element>
+			        </xsl:otherwise>
+			    </xsl:choose>
                         </xsl:when>
                         <xsl:otherwise>
                             <xsl:attribute name="gco:nilReason">unknown</xsl:attribute>


### PR DESCRIPTION
- Added Spatial Representation to vocabulary. 
- Updated mmd-to-geonorge to pick up only compliant values of spatial representation (only vector and grid are valid entries, other mmd supported entries are only internal)
- Update mmd-to-geonorge publication date (this is not part of #226 , but while testing the changes I've noticed that publication_date is the xsd is not forced to be a xs:date, only xs:string, documentation says we expect a date (not datetime), but several mmd records are not following this and provide datetime instead)

Closes #226 