### PR TITLE
Add support for CC-BY-3.0

### DIFF
--- a/doc/ch04-md-contrvocabs.adoc
+++ b/doc/ch04-md-contrvocabs.adoc
@@ -199,6 +199,8 @@ externally.
 
 | CC0-1.0   | http://spdx.org/licenses/CC0-1.0 | Public domain. All rights for these data are waived. The person who associated a work with this deed has dedicated the work to the public domain by waiving all of his or her rights to the work worldwide under copyright law, including all related and neighboring rights, to the extent allowed by law. This is relevant to release datasets into the public domain.
 
+| CC-BY-3.0 | http://spdx.org/licenses/CC-BY-3.0| Attribution alone. This is an old version of the CC-BY-4.0 license. It is strongly recommend the use of the CC-BY-4.0 license instead.
+
 | CC-BY-4.0 | http://spdx.org/licenses/CC-BY-4.0| Attribution alone. This license lets others distribute, remix, adapt, and build upon your work, even commercially, as long as they credit you for the original creation. This is the most accommodating of licenses offered. Recommended for maximum dissemination and use of licensed materials. 
 
 | CC-BY-SA-4.0 | http://spdx.org/licenses/CC-BY-SA-4.0 | Attribution + ShareAlike. This license lets others remix, adapt, and build upon your work even for commercial purposes, as long as they credit you and license their new creations under the identical terms. This license is often compared to “copyleft” free and open source software licenses. All new works based on yours will carry the same license, so any derivatives will also allow commercial use. This is the license used by Wikipedia, and is recommended for materials that would benefit from incorporating content from Wikipedia and similarly licensed projects. 

--- a/thesauri/mmd-vocabulary.ttl
+++ b/thesauri/mmd-vocabulary.ttl
@@ -124,8 +124,9 @@
   a skos:Collection, isothes:ConceptGroup ;
   skos:inScheme <https://vocab.met.no/mmd>; 
   skos:prefLabel "Use Constraint"@en ;
+  skos:changeNote "Added support for CC-BY-3.0"@en ;
   skos:definition "A controlled vocabulary to be used to describe constraints on the usage of metadata and/or data. Ideally as little constraints as possible is defined. The definitions below relate to Creative Commons."@en ;
-  skos:member <https://vocab.met.no/mmd/Use_Constraint/CC0-1.0>, <https://vocab.met.no/mmd/Use_Constraint/CC-BY-4.0>, <https://vocab.met.no/mmd/Use_Constraint/CC-BY-SA-4.0>, <https://vocab.met.no/mmd/Use_Constraint/CC-BY-NC-4.0>, <https://vocab.met.no/mmd/Use_Constraint/CC-BY-NC-SA-4.0>, <https://vocab.met.no/mmd/Use_Constraint/CC-BY-ND-4.0>, <https://vocab.met.no/mmd/Use_Constraint/CC-BY-NC-ND-4.0> .
+  skos:member <https://vocab.met.no/mmd/Use_Constraint/CC0-1.0>, <https://vocab.met.no/mmd/Use_Constraint/CC-BY-3.0>, <https://vocab.met.no/mmd/Use_Constraint/CC-BY-4.0>, <https://vocab.met.no/mmd/Use_Constraint/CC-BY-SA-4.0>, <https://vocab.met.no/mmd/Use_Constraint/CC-BY-NC-4.0>, <https://vocab.met.no/mmd/Use_Constraint/CC-BY-NC-SA-4.0>, <https://vocab.met.no/mmd/Use_Constraint/CC-BY-ND-4.0>, <https://vocab.met.no/mmd/Use_Constraint/CC-BY-NC-ND-4.0> .
 
 <https://vocab.met.no/mmd/Use_Constraint/CC0-1.0>
   a skos:Concept ;
@@ -133,6 +134,13 @@
   skos:altLabel "Creative Commons Zero v1.0 Universal"@en, "CC0 – Creative Commons"@en ;
   skos:exactMatch <https://creativecommons.org/share-your-work/public-domain/cc0/feed/rdf/>, <http://spdx.org/licenses/CC0-1.0>, <https://creativecommons.org/share-your-work/public-domain/cc0/> ;
   skos:definition "The person who associated a work with this deed has dedicated the work to the public domain by waiving all of his or her rights to the work worldwide under copyright law, including all related and neighboring rights, to the extent allowed by law."@en .
+
+<https://vocab.met.no/mmd/Use_Constraint/CC-BY-3.0>
+  a skos:Concept ;
+  skos:prefLabel "CC-BY-3.0"@en ;
+  skos:altLabel "Creative Commons Attribution 3.0 Unported"@en ;
+  skos:exactMatch <https://spdx.org/licenses/CC-BY-3.0>, <https://creativecommons.org/licenses/by/3.0/rdf>, <https://creativecommons.org/licenses/by/3.0/> ;
+  skos:definition "This is an old version of the CC-BY-4.0 license. It is strongly recommend the use of the CC-BY-4.0 license instead."@en .
 
 <https://vocab.met.no/mmd/Use_Constraint/CC-BY-4.0>
   a skos:Concept ;

--- a/thesauri/mmd-vocabulary.ttl
+++ b/thesauri/mmd-vocabulary.ttl
@@ -139,7 +139,7 @@
   a skos:Concept ;
   skos:prefLabel "CC-BY-3.0"@en ;
   skos:altLabel "Creative Commons Attribution 3.0 Unported"@en ;
-  skos:exactMatch <https://spdx.org/licenses/CC-BY-3.0>, <https://creativecommons.org/licenses/by/3.0/rdf>, <https://creativecommons.org/licenses/by/3.0/> ;
+  skos:exactMatch <http://spdx.org/licenses/CC-BY-3.0>, <https://creativecommons.org/licenses/by/3.0/rdf>, <https://creativecommons.org/licenses/by/3.0/> ;
   skos:definition "This is an old version of the CC-BY-4.0 license. It is strongly recommend the use of the CC-BY-4.0 license instead."@en .
 
 <https://vocab.met.no/mmd/Use_Constraint/CC-BY-4.0>

--- a/thesauri/mmd-vocabulary.xml
+++ b/thesauri/mmd-vocabulary.xml
@@ -157,6 +157,7 @@
     <rdf:type rdf:resource="http://purl.org/iso25964/skos-thes#ConceptGroup"/>
     <skos:inScheme rdf:resource="https://vocab.met.no/mmd"/>
     <skos:prefLabel xml:lang="en">Use Constraint</skos:prefLabel>
+    <skos:changeNote xml:lang="en">Added support for CC-BY-3.0</skos:changeNote>
     <skos:definition xml:lang="en">A controlled vocabulary to be used to describe constraints on the usage of metadata and/or data. Ideally as little constraints as possible is defined. The definitions below relate to Creative Commons.</skos:definition>
     <skos:member>
       <skos:Concept rdf:about="https://vocab.met.no/mmd/Use_Constraint/CC0-1.0">
@@ -167,6 +168,17 @@
         <skos:exactMatch rdf:resource="http://spdx.org/licenses/CC0-1.0"/>
         <skos:exactMatch rdf:resource="https://creativecommons.org/share-your-work/public-domain/cc0/"/>
         <skos:definition xml:lang="en">The person who associated a work with this deed has dedicated the work to the public domain by waiving all of his or her rights to the work worldwide under copyright law, including all related and neighboring rights, to the extent allowed by law.</skos:definition>
+      </skos:Concept>
+    </skos:member>
+
+    <skos:member>
+      <skos:Concept rdf:about="https://vocab.met.no/mmd/Use_Constraint/CC-BY-3.0">
+        <skos:prefLabel xml:lang="en">CC-BY-3.0</skos:prefLabel>
+        <skos:altLabel xml:lang="en">Creative Commons Attribution 3.0 Unported</skos:altLabel>
+        <skos:exactMatch rdf:resource="http://spdx.org/licenses/CC-BY-3.0"/>
+        <skos:exactMatch rdf:resource="https://creativecommons.org/licenses/by/3.0/rdf"/>
+        <skos:exactMatch rdf:resource="https://creativecommons.org/licenses/by/3.0/"/>
+        <skos:definition xml:lang="en">This is an old version of the CC-BY-4.0 license. It is strongly recommend the use of the CC-BY-4.0 license instead.</skos:definition>
       </skos:Concept>
     </skos:member>
 

--- a/xsd/mmd.xsd
+++ b/xsd/mmd.xsd
@@ -155,6 +155,7 @@
     <xs:simpleType name="use_constraint_identifier_type">
         <xs:restriction base="xs:string">
             <xs:enumeration value="CC0-1.0"></xs:enumeration>
+            <xs:enumeration value="CC-BY-3.0"></xs:enumeration>
             <xs:enumeration value="CC-BY-4.0"></xs:enumeration>
             <xs:enumeration value="CC-BY-SA-4.0"></xs:enumeration>
             <xs:enumeration value="CC-BY-NC-4.0"></xs:enumeration>
@@ -166,6 +167,7 @@
     <xs:simpleType name="use_constraint_resource_type">
         <xs:restriction base="xs:string">
             <xs:enumeration value="http://spdx.org/licenses/CC0-1.0"></xs:enumeration>
+            <xs:enumeration value="http://spdx.org/licenses/CC-BY-3.0"></xs:enumeration>
             <xs:enumeration value="http://spdx.org/licenses/CC-BY-4.0"></xs:enumeration>
             <xs:enumeration value="http://spdx.org/licenses/CC-BY-SA-4.0"></xs:enumeration>
             <xs:enumeration value="http://spdx.org/licenses/CC-BY-NC-4.0"></xs:enumeration>

--- a/xsd/mmd_strict.xsd
+++ b/xsd/mmd_strict.xsd
@@ -165,6 +165,7 @@
     <xs:simpleType name="use_constraint_identifier_type">
         <xs:restriction base="xs:string">
             <xs:enumeration value="CC0-1.0"></xs:enumeration>
+            <xs:enumeration value="CC-BY-3.0"></xs:enumeration>
             <xs:enumeration value="CC-BY-4.0"></xs:enumeration>
             <xs:enumeration value="CC-BY-SA-4.0"></xs:enumeration>
             <xs:enumeration value="CC-BY-NC-4.0"></xs:enumeration>
@@ -177,6 +178,8 @@
         <xs:restriction base="xs:string">
             <xs:enumeration value="http://spdx.org/licenses/CC0-1.0"></xs:enumeration>
             <xs:enumeration value="https://spdx.org/licenses/CC0-1.0"></xs:enumeration>
+            <xs:enumeration value="http://spdx.org/licenses/CC-BY-3.0"></xs:enumeration>
+            <xs:enumeration value="https://spdx.org/licenses/CC-BY-3.0"></xs:enumeration>
             <xs:enumeration value="http://spdx.org/licenses/CC-BY-4.0"></xs:enumeration>
             <xs:enumeration value="https://spdx.org/licenses/CC-BY-4.0"></xs:enumeration>
             <xs:enumeration value="http://spdx.org/licenses/CC-BY-SA-4.0"></xs:enumeration>

--- a/xslt/mmd-to-geonorge.xsl
+++ b/xslt/mmd-to-geonorge.xsl
@@ -1031,6 +1031,7 @@
 
     <!--Mapping to https://register.geonorge.no/metadata-kodelister/lisenser-->
     <mapping:use_constraint geon="Creative Commons 0" mmd="CC0-1.0" />    
+    <mapping:use_constraint geon="Creative Commons BY 3.0 (CC BY 3.0)" mmd="CC-BY-3.0" />
     <mapping:use_constraint geon="Creative Commons BY 4.0 (CC BY 4.0)" mmd="CC-BY-4.0" />    
     <mapping:use_constraint geon="Creative Commons BY-NC 4.0 (CC BY-NC 4.0)" mmd="CC-BY-NC-4.0" />    
 </xsl:stylesheet>


### PR DESCRIPTION
The changes are the following: 

- added CC-BY-3.0 in the documentation for controlled vocabularies
- added CC-BY-3.0 in the thesauri files
- added CC-BY-3.0 in the schemas (mmd and mmd_strict)
- added translation to genorge code in mmd-to-genorge

Closes #229 