### PR TITLE
Added a test to handle DIF10 records from NPI

### DIFF
--- a/xslt/dif-to-mmd.xsl
+++ b/xslt/dif-to-mmd.xsl
@@ -702,7 +702,8 @@ Added more support for DIF 10 Øystein Godøy, METNO/FOU, 2023-04-24
                     <xsl:variable name="datetimestr">
                         <xsl:value-of select="dif:Metadata_Last_Revision" />
                     </xsl:variable>
-                    <xsl:if test="string-length($datetimestr) = 8 and translate($datetimestr,'0123456789','') = ''">
+		    <!--DIF 10 supports also a DateEnum vocabulary that is not datetime type-->
+                    <xsl:if test="$datetimestr != 'Not provided' and $datetimestr !='unknown' and $datetimestr !='present' and $datetimestr !='unbounded' and $datetimestr !='future' and translate($datetimestr, '1234567890', '') != $datetimestr">
                         <xsl:element name="mmd:update">
                             <xsl:element name="mmd:datetime">
                                 <xsl:value-of select="dif:Metadata_Last_Revision" />

--- a/xslt/dif-to-mmd.xsl
+++ b/xslt/dif-to-mmd.xsl
@@ -699,17 +699,22 @@ Added more support for DIF 10 Øystein Godøy, METNO/FOU, 2023-04-24
                     </xsl:element>
                 </xsl:if>
                 <xsl:if test="dif:Metadata_Last_Revision" >
-                    <xsl:element name="mmd:update">
-                        <xsl:element name="mmd:datetime">
-                            <xsl:value-of select="dif:Metadata_Last_Revision" />
+                    <xsl:variable name="datetimestr">
+                        <xsl:value-of select="dif:Metadata_Last_Revision" />
+                    </xsl:variable>
+                    <xsl:if test="string-length($datetimestr) = 8 and translate($datetimestr,'0123456789','') = ''">
+                        <xsl:element name="mmd:update">
+                            <xsl:element name="mmd:datetime">
+                                <xsl:value-of select="dif:Metadata_Last_Revision" />
+                            </xsl:element>
+                            <xsl:element name="mmd:type">
+                                <xsl:text>Major modification</xsl:text>
+                            </xsl:element>
+                            <xsl:element name="mmd:note">
+                                <xsl:text>Captured from DIF10 record</xsl:text>
+                            </xsl:element>
                         </xsl:element>
-                        <xsl:element name="mmd:type">
-                            <xsl:text>Major modification</xsl:text>
-                        </xsl:element>
-                        <xsl:element name="mmd:note">
-                            <xsl:text>Captured from DIF10 record</xsl:text>
-                        </xsl:element>
-                    </xsl:element>
+                    </xsl:if>
                 </xsl:if>
             </xsl:element>
         </xsl:template>


### PR DESCRIPTION
NPI releases DIF10 records with an appearance like:
'''
<Metadata_Dates>
    <Metadata_Creation>2023-12-04T17:11:12Z</Metadata_Creation>
    <Metadata_Last_Revision>Not provided</Metadata_Last_Revision>
    <Data_Creation>Not provided</Data_Creation>
    <Data_Last_Revision>Not provided</Data_Last_Revision>
  </Metadata_Dates>
'''
This cause issues on ingestion side for MMD records which have dates of type "Not provided". A hack to prevent such strings to pass through has been added. Full datetime validation would be easier with XSLT 2, but for now we are using XSLT 1.