### PR TITLE
parent/child support and some minor updates to xsl

### DIFF
--- a/xslt/mmd-to-dif.xsl
+++ b/xslt/mmd-to-dif.xsl
@@ -4,7 +4,12 @@
     xmlns:dif="http://gcmd.gsfc.nasa.gov/Aboutus/xml/dif/" 
     xmlns:mmd="http://www.met.no/schema/mmd"
     xmlns:mapping="http://www.met.no/schema/mmd/mmd2dif"      
+    xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
     xmlns:dc="http://purl.org/dc/elements/1.1/" version="1.0">
+
+        <xsl:key name="isoc" match="skos:Collection[@rdf:about='https://vocab.met.no/mmd/ISO_Topic_Category']/skos:member/skos:Concept" use="skos:prefLabel"/>
+        <xsl:variable name="isoLUD" select="document('../thesauri/mmd-vocabulary.xml')"/>
 	<xsl:output method="xml" encoding="UTF-8" indent="yes" />
 
 	<xsl:template match="/mmd:mmd">
@@ -50,6 +55,7 @@
 			<xsl:apply-templates select="mmd:abstract" />
                         <xsl:apply-templates select="mmd:related_information"/>
 			<xsl:apply-templates select="mmd:data_access" />
+			<xsl:apply-templates select="mmd:related_dataset" />
 			<xsl:apply-templates select="mmd:quality" />
 
 			<xsl:element name="dif:Metadata_Name">CEOS IDN DIF</xsl:element>
@@ -79,6 +85,14 @@
 		            <xsl:value-of select="." />
 			</xsl:element>
 		        <xsl:element name="dif:Purpose" />
+		    </xsl:element>
+	        </xsl:if>
+	</xsl:template>
+
+	<xsl:template match="mmd:related_dataset">
+		<xsl:if test="@relation_type = 'parent' and . !=''">
+		    <xsl:element name="dif:Parent_DIF">
+		        <xsl:value-of select="." />
 		    </xsl:element>
 	        </xsl:if>
 	</xsl:template>
@@ -419,9 +433,14 @@
 	</xsl:template>
 
 	<xsl:template match="mmd:iso_topic_category">
+            <xsl:variable name="isov" select="." />
+            <xsl:for-each select="$isoLUD">
+                <xsl:value-of select ="name()" />
+                <xsl:variable name="isoe" select="key('isoc',$isov)/skos:altLabel"/>
 		<xsl:element name="dif:ISO_Topic_Category">
-			<xsl:value-of select="." />
+		    <xsl:value-of select="$isoe" />
 		</xsl:element>
+            </xsl:for-each>
 	</xsl:template>
 
 	<xsl:template match="mmd:keywords">
@@ -497,9 +516,11 @@
         </xsl:template>
 
         <xsl:template match="mmd:personnel">
+	    <xsl:variable name="lowercase" select="'abcdefghijklmnopqrstuvwxyz'" />
+	    <xsl:variable name="uppercase" select="'ABCDEFGHIJKLMNOPQRSTUVWXYZ'" />
             <xsl:element name="dif:Personnel">
                 <xsl:element name="dif:Role">
-                    <xsl:value-of select="mmd:role" />
+                    <xsl:value-of select="translate(mmd:role,$lowercase,$uppercase)" />
                 </xsl:element>
                 <!--
                 <xsl:element name="dif:First_Name">
@@ -556,7 +577,7 @@
                     <xsl:element name="dif:Related_URL">
                         <xsl:element name="dif:URL_Content_Type">
                             <xsl:element name="dif:Type">
-                                <xsl:text>VIEW DATASET LANDING PAGE</xsl:text>
+                                <xsl:text>VIEW DATA SET LANDING PAGE</xsl:text>
                             </xsl:element>
                         </xsl:element>
                         <xsl:element name="dif:URL">

--- a/xslt/mmd-to-dif10.xsl
+++ b/xslt/mmd-to-dif10.xsl
@@ -4,7 +4,11 @@
 	xmlns:dif="http://gcmd.gsfc.nasa.gov/Aboutus/xml/dif/"
 	xmlns:mmd="http://www.met.no/schema/mmd"
         xmlns:mapping="http://www.met.no/schema/mmd/mmd2dif"
+        xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+        xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 	xmlns:dc="http://purl.org/dc/elements/1.1/" version="1.0">
+        <xsl:key name="isoc" match="skos:Collection[@rdf:about='https://vocab.met.no/mmd/ISO_Topic_Category']/skos:member/skos:Concept" use="skos:prefLabel"/>
+        <xsl:variable name="isoLUD" select="document('../thesauri/mmd-vocabulary.xml')"/>
 	<xsl:output method="xml" encoding="UTF-8" indent="yes" />
 
 	<xsl:template match="/mmd:mmd">
@@ -65,6 +69,7 @@
 			<xsl:apply-templates select="mmd:abstract[@xml:lang = 'en']" />
 			<xsl:apply-templates select="mmd:related_information"/> <!--tbd-->
 			<xsl:apply-templates select="mmd:data_access" />
+			<xsl:apply-templates select="mmd:related_dataset" />
 
 			<xsl:element name="dif:Metadata_Name">CEOS IDN DIF</xsl:element>
 			<xsl:element name="dif:Metadata_Version">VERSION 10.3</xsl:element>
@@ -79,7 +84,7 @@
 			<xsl:value-of select="." />
 		    </xsl:element>
 		    <xsl:element name="dif:Version">
-                        <xsl:text>1.0</xsl:text>
+                        <xsl:text>Not provided</xsl:text>
 		    </xsl:element>
 		</xsl:element>
 	</xsl:template>
@@ -103,7 +108,7 @@
                     <xsl:element name="dif:Related_URL">
                         <xsl:element name="dif:URL_Content_Type">
                             <xsl:element name="dif:Type">
-                                <xsl:text>DATASET LANDING PAGE</xsl:text>
+                                <xsl:text>DATA SET LANDING PAGE</xsl:text>
                             </xsl:element>
                         </xsl:element>
                         <xsl:element name="dif:URL">
@@ -516,6 +521,24 @@
 	    </xsl:element>
 	</xsl:template>
 
+	<xsl:template match="mmd:related_dataset">
+		<xsl:if test="@relation_type = 'parent' and . !=''">
+		    <xsl:element name="dif:Metadata_Association">
+			    <xsl:element name="dif:Entry_ID">
+			    <xsl:element name="dif:Short_Name">
+		               <xsl:value-of select="." />
+		            </xsl:element>
+			    <xsl:element name="dif:Version">
+                               <xsl:text>Not provided</xsl:text>
+		            </xsl:element>
+		            </xsl:element>
+			    <xsl:element name="dif:Type">
+			       <xsl:text>Parent</xsl:text>
+		            </xsl:element>
+		    </xsl:element>
+	        </xsl:if>
+	</xsl:template>
+
 	<xsl:template match="mmd:project">
 		<xsl:element name="dif:Project">
 			<xsl:element name="dif:Short_Name">
@@ -599,9 +622,14 @@
 	</xsl:template>
 
 	<xsl:template match="mmd:iso_topic_category">
+            <xsl:variable name="isov" select="." />
+            <xsl:for-each select="$isoLUD">
+                <xsl:value-of select ="name()" />
+                <xsl:variable name="isoe" select="key('isoc',$isov)/skos:altLabel"/>
 		<xsl:element name="dif:ISO_Topic_Category">
-			<xsl:value-of select="." />
+		    <xsl:value-of select="$isoe" />
 		</xsl:element>
+            </xsl:for-each>
 	</xsl:template>
 
         <xsl:template match="mmd:keywords">


### PR DESCRIPTION
This closes #239 but we are lacking full support of parent/child for dif10. We can expose the relation to the parent from a child, but not the relation of the children from a parent, as we are missing this information. It could be eventually handled through the solr. 
Here the summary of the modifications: 

mmd-to-dif: 
- added related_dataset translation
- translating now iso_topic_category with mmd-vocabulary.xml
- capitalize personnel role
- correct type of landing page

mmd-to-dif10:
- added related_dataset translation (only parent support)
- translating now iso_topic_category with mmd-vocabulary.xml
- correct type of landing page

mmd-to-inspire:
- added support for reading parent_list of identifiers
- added parentIdentifier
- choice of hierarcy level depending on parent/child
- updated metadata contact to support multiple entries
- make sure one date is provided (required in inspire)

mmd-to-wmo
- added support for reading parent_list of identifiers
- added parentIdentifier
- choice of hierarcy level depending on parent/child
- updated metadata contact to support multiple entries
- corrected dateStamp codeList
- added referenceSystemInfo
- added indetifier in citation
- added gmd:status
- updated WMO_DistributionScopeCode
- added distributor
- added landing page (onLine/URL)

This has been tested on a csw test endpoint. 