### PR TITLE
minor changes in license vocabulary and inclusion of Use_Constraint translation in dif-to-mmd

### DIFF
--- a/thesauri/mmd-vocabulary.ttl
+++ b/thesauri/mmd-vocabulary.ttl
@@ -124,64 +124,64 @@
   a skos:Collection, isothes:ConceptGroup ;
   skos:inScheme <https://vocab.met.no/mmd>; 
   skos:prefLabel "Use Constraint"@en ;
-  skos:changeNote "Added support for CC-BY-3.0"@en ;
+  skos:changeNote "Added support for CC-BY-3.0"@en, "Added more altLabel"@en ;
   skos:definition "A controlled vocabulary to be used to describe constraints on the usage of metadata and/or data. Ideally as little constraints as possible is defined. The definitions below relate to Creative Commons."@en ;
   skos:member <https://vocab.met.no/mmd/Use_Constraint/CC0-1.0>, <https://vocab.met.no/mmd/Use_Constraint/CC-BY-3.0>, <https://vocab.met.no/mmd/Use_Constraint/CC-BY-4.0>, <https://vocab.met.no/mmd/Use_Constraint/CC-BY-SA-4.0>, <https://vocab.met.no/mmd/Use_Constraint/CC-BY-NC-4.0>, <https://vocab.met.no/mmd/Use_Constraint/CC-BY-NC-SA-4.0>, <https://vocab.met.no/mmd/Use_Constraint/CC-BY-ND-4.0>, <https://vocab.met.no/mmd/Use_Constraint/CC-BY-NC-ND-4.0> .
 
 <https://vocab.met.no/mmd/Use_Constraint/CC0-1.0>
   a skos:Concept ;
   skos:prefLabel "CC0-1.0"@en ;
-  skos:altLabel "Creative Commons Zero v1.0 Universal"@en, "CC0 – Creative Commons"@en ;
-  skos:exactMatch <https://creativecommons.org/share-your-work/public-domain/cc0/feed/rdf/>, <http://spdx.org/licenses/CC0-1.0>, <https://creativecommons.org/share-your-work/public-domain/cc0/> ;
+  skos:altLabel "Creative Commons Zero v1.0 Universal"@en, "CC0 1.0"@en ;
+  skos:exactMatch <http://spdx.org/licenses/CC0-1.0>, <https://creativecommons.org/publicdomain/zero/1.0/> ;
   skos:definition "The person who associated a work with this deed has dedicated the work to the public domain by waiving all of his or her rights to the work worldwide under copyright law, including all related and neighboring rights, to the extent allowed by law."@en .
 
 <https://vocab.met.no/mmd/Use_Constraint/CC-BY-3.0>
   a skos:Concept ;
   skos:prefLabel "CC-BY-3.0"@en ;
-  skos:altLabel "Creative Commons Attribution 3.0 Unported"@en ;
-  skos:exactMatch <http://spdx.org/licenses/CC-BY-3.0>, <https://creativecommons.org/licenses/by/3.0/rdf>, <https://creativecommons.org/licenses/by/3.0/> ;
+  skos:altLabel "Creative Commons Attribution 3.0 Unported"@en, "CC BY 3.0"@en;
+  skos:exactMatch <http://spdx.org/licenses/CC-BY-3.0>, <https://creativecommons.org/licenses/by/3.0/> ;
   skos:definition "This is an old version of the CC-BY-4.0 license. It is strongly recommend the use of the CC-BY-4.0 license instead."@en .
 
 <https://vocab.met.no/mmd/Use_Constraint/CC-BY-4.0>
   a skos:Concept ;
   skos:prefLabel "CC-BY-4.0"@en ;
-  skos:altLabel "Creative Commons Attribution 4.0 International"@en, "Attribution"@en, "Navngivelse"@nb ;
-  skos:exactMatch <http://spdx.org/licenses/CC-BY-4.0>, <https://creativecommons.org/licenses/by/4.0/rdf>, <https://creativecommons.org/licenses/by/4.0/> ;
+  skos:altLabel "Creative Commons Attribution 4.0 International"@en, "CC BY 4.0"@en, "Attribution"@en, "Navngivelse"@nb ;
+  skos:exactMatch <http://spdx.org/licenses/CC-BY-4.0>, <https://creativecommons.org/licenses/by/4.0/> ;
   skos:definition "This license lets others distribute, remix, adapt, and build upon your work, even commercially, as long as they credit you for the original creation. This is the most accommodating of licenses offered. Recommended for maximum dissemination and use of licensed materials."@en .
 
 <https://vocab.met.no/mmd/Use_Constraint/CC-BY-SA-4.0>
   a skos:Concept ;
   skos:prefLabel "CC-BY-SA-4.0"@en ;
-  skos:altLabel "Creative Commons Attribution Share Alike 4.0 International"@en, "Attribution-ShareAlike"@en, "Navngivelse-DelPåSammeVilkår"@nb ;
-  skos:exactMatch <http://spdx.org/licenses/CC-BY-SA-4.0>, <https://creativecommons.org/licenses/by-sa/4.0/rdf>, <https://creativecommons.org/licenses/by-sa/4.0/> ;
+  skos:altLabel "Creative Commons Attribution Share Alike 4.0 International"@en, "CC BY-SA 4.0"@en, "Attribution-ShareAlike"@en, "Navngivelse-DelPåSammeVilkår"@nb ;
+  skos:exactMatch <http://spdx.org/licenses/CC-BY-SA-4.0>, <https://creativecommons.org/licenses/by-sa/4.0/> ;
   skos:definition "This license lets others remix, adapt, and build upon your work even for commercial purposes, as long as they credit you and license their new creations under the identical terms. This license is often compared to “copyleft” free and open source software licenses. All new works based on yours will carry the same license, so any derivatives will also allow commercial use. This is the license used by Wikipedia, and is recommended for materials that would benefit from incorporating content from Wikipedia and similarly licensed projects."@en .
 
 <https://vocab.met.no/mmd/Use_Constraint/CC-BY-NC-4.0>
   a skos:Concept ;
   skos:prefLabel "CC-BY-NC-4.0"@en ;
-  skos:altLabel "Creative Commons Attribution Non Commercial 4.0 International"@en, "Attribution-NonCommercial"@en, "Navngivelse-IkkeKommersiell"@nb ;
-  skos:exactMatch <http://spdx.org/licenses/CC-BY-NC-4.0>, <https://creativecommons.org/licenses/by-nc/4.0/rdf>, <https://creativecommons.org/licenses/by-nc/4.0/> ;
+  skos:altLabel "Creative Commons Attribution Non Commercial 4.0 International"@en, "CC BY-NC 4.0"@en, "Attribution-NonCommercial"@en, "Navngivelse-IkkeKommersiell"@nb ;
+  skos:exactMatch <http://spdx.org/licenses/CC-BY-NC-4.0>, <https://creativecommons.org/licenses/by-nc/4.0/> ;
   skos:definition "This license lets others remix, adapt, and build upon your work non-commercially, and although their new works must also acknowledge you and be non-commercial, they don’t have to license their derivative works on the same terms."@en .
 
 <https://vocab.met.no/mmd/Use_Constraint/CC-BY-NC-SA-4.0>
   a skos:Concept ;
   skos:prefLabel "CC-BY-NC-SA-4.0"@en ;
-  skos:altLabel "Creative Commons Attribution Non Commercial Share Alike 4.0 International"@en, "Attribution-NonCommercial-ShareAlike"@en, "Navngivelse-IkkeKommersiell-DelPåSammeVilkår"@nb ;
-  skos:exactMatch <http://spdx.org/licenses/CC-BY-NC-SA-4.0>, <https://creativecommons.org/licenses/by-nc-sa/4.0/rdf>, <https://creativecommons.org/licenses/by-nc-sa/4.0/> ;
+  skos:altLabel "Creative Commons Attribution Non Commercial Share Alike 4.0 International"@en, "CC BY-NC-SA 4.0"@en, "Attribution-NonCommercial-ShareAlike"@en, "Navngivelse-IkkeKommersiell-DelPåSammeVilkår"@nb ;
+  skos:exactMatch <http://spdx.org/licenses/CC-BY-NC-SA-4.0>, <https://creativecommons.org/licenses/by-nc-sa/4.0/> ;
   skos:definition "This license lets others remix, adapt, and build upon your work non-commercially, as long as they credit you and license their new creations under the identical terms."@en .
 
 <https://vocab.met.no/mmd/Use_Constraint/CC-BY-ND-4.0>
   a skos:Concept ;
   skos:prefLabel "CC-BY-ND-4.0"@en ;
-  skos:altLabel "Creative Commons Attribution No Derivatives 4.0 International"@en, "Attribution-NoDerivs"@en, "Navngivelse-IngenBearbeidelse"@nb ;
-  skos:exactMatch <http://spdx.org/licenses/CC-BY-ND-4.0>, <https://creativecommons.org/licenses/by-nd/4.0/rdf>, <https://creativecommons.org/licenses/by-nd/4.0/> ;
+  skos:altLabel "Creative Commons Attribution No Derivatives 4.0 International"@en, "CC BY-ND 4.0"@en, "Attribution-NoDerivs"@en, "Navngivelse-IngenBearbeidelse"@nb ;
+  skos:exactMatch <http://spdx.org/licenses/CC-BY-ND-4.0>, <https://creativecommons.org/licenses/by-nd/4.0/> ;
   skos:definition "This license lets others reuse the work for any purpose, including commercially; however, it cannot be shared with others in adapted form, and credit must be provided to you."@en .
 
 <https://vocab.met.no/mmd/Use_Constraint/CC-BY-NC-ND-4.0>
   a skos:Concept ;
   skos:prefLabel "CC-BY-NC-ND-4.0"@en ;
-  skos:altLabel "Creative Commons Attribution Non Commercial No Derivatives 4.0 International"@en, "Attribution-NonCommercial-NoDerivs"@en, "Navngivelse-IkkeKommersiell-IngenBearbeidelser"@nb ;
-  skos:exactMatch <http://spdx.org/licenses/CC-BY-NC-ND4.0>, <https://creativecommons.org/licenses/by-nc-nd/4.0/rdf>, <https://creativecommons.org/licenses/by-nc-nd/4.0/> ;
+  skos:altLabel "Creative Commons Attribution Non Commercial No Derivatives 4.0 International"@en, "CC BY-NC-ND 4.0"@en, "Attribution-NonCommercial-NoDerivs"@en, "Navngivelse-IkkeKommersiell-IngenBearbeidelser"@nb ;
+  skos:exactMatch <http://spdx.org/licenses/CC-BY-NC-ND-4.0>, <https://creativecommons.org/licenses/by-nc-nd/4.0/> ;
   skos:definition "This license is the most restrictive of our six main licenses, only allowing others to download your works and share them with others as long as they credit you, but they can’t change them in any way or use them commercially."@en .
 
 

--- a/thesauri/mmd-vocabulary.xml
+++ b/thesauri/mmd-vocabulary.xml
@@ -158,15 +158,15 @@
     <skos:inScheme rdf:resource="https://vocab.met.no/mmd"/>
     <skos:prefLabel xml:lang="en">Use Constraint</skos:prefLabel>
     <skos:changeNote xml:lang="en">Added support for CC-BY-3.0</skos:changeNote>
+    <skos:changeNote xml:lang="en">Added more altLabel</skos:changeNote>
     <skos:definition xml:lang="en">A controlled vocabulary to be used to describe constraints on the usage of metadata and/or data. Ideally as little constraints as possible is defined. The definitions below relate to Creative Commons.</skos:definition>
     <skos:member>
       <skos:Concept rdf:about="https://vocab.met.no/mmd/Use_Constraint/CC0-1.0">
         <skos:prefLabel xml:lang="en">CC0-1.0</skos:prefLabel>
         <skos:altLabel xml:lang="en">Creative Commons Zero v1.0 Universal</skos:altLabel>
-        <skos:altLabel xml:lang="en">CC0 – Creative Commons</skos:altLabel>
-        <skos:exactMatch rdf:resource="https://creativecommons.org/share-your-work/public-domain/cc0/feed/rdf/"/>
+        <skos:altLabel xml:lang="en">CC0 1.0</skos:altLabel>
         <skos:exactMatch rdf:resource="http://spdx.org/licenses/CC0-1.0"/>
-        <skos:exactMatch rdf:resource="https://creativecommons.org/share-your-work/public-domain/cc0/"/>
+        <skos:exactMatch rdf:resource="https://creativecommons.org/publicdomain/zero/1.0/"/>
         <skos:definition xml:lang="en">The person who associated a work with this deed has dedicated the work to the public domain by waiving all of his or her rights to the work worldwide under copyright law, including all related and neighboring rights, to the extent allowed by law.</skos:definition>
       </skos:Concept>
     </skos:member>
@@ -175,8 +175,8 @@
       <skos:Concept rdf:about="https://vocab.met.no/mmd/Use_Constraint/CC-BY-3.0">
         <skos:prefLabel xml:lang="en">CC-BY-3.0</skos:prefLabel>
         <skos:altLabel xml:lang="en">Creative Commons Attribution 3.0 Unported</skos:altLabel>
+        <skos:altLabel xml:lang="en">CC BY 3.0</skos:altLabel>
         <skos:exactMatch rdf:resource="http://spdx.org/licenses/CC-BY-3.0"/>
-        <skos:exactMatch rdf:resource="https://creativecommons.org/licenses/by/3.0/rdf"/>
         <skos:exactMatch rdf:resource="https://creativecommons.org/licenses/by/3.0/"/>
         <skos:definition xml:lang="en">This is an old version of the CC-BY-4.0 license. It is strongly recommend the use of the CC-BY-4.0 license instead.</skos:definition>
       </skos:Concept>
@@ -186,10 +186,10 @@
       <skos:Concept rdf:about="https://vocab.met.no/mmd/Use_Constraint/CC-BY-4.0">
         <skos:prefLabel xml:lang="en">CC-BY-4.0</skos:prefLabel>
         <skos:altLabel xml:lang="en">Creative Commons Attribution 4.0 International</skos:altLabel>
+        <skos:altLabel xml:lang="en">CC BY 4.0</skos:altLabel>
         <skos:altLabel xml:lang="en">Attribution</skos:altLabel>
         <skos:altLabel xml:lang="nb">Navngivelse</skos:altLabel>
         <skos:exactMatch rdf:resource="http://spdx.org/licenses/CC-BY-4.0"/>
-        <skos:exactMatch rdf:resource="https://creativecommons.org/licenses/by/4.0/rdf"/>
         <skos:exactMatch rdf:resource="https://creativecommons.org/licenses/by/4.0/"/>
         <skos:definition xml:lang="en">This license lets others distribute, remix, adapt, and build upon your work, even commercially, as long as they credit you for the original creation. This is the most accommodating of licenses offered. Recommended for maximum dissemination and use of licensed materials.</skos:definition>
       </skos:Concept>
@@ -199,10 +199,10 @@
       <skos:Concept rdf:about="https://vocab.met.no/mmd/Use_Constraint/CC-BY-SA-4.0">
         <skos:prefLabel xml:lang="en">CC-BY-SA-4.0</skos:prefLabel>
         <skos:altLabel xml:lang="en">Creative Commons Attribution Share Alike 4.0 International</skos:altLabel>
+        <skos:altLabel xml:lang="en">CC BY-SA 4.0</skos:altLabel>
         <skos:altLabel xml:lang="en">Attribution-ShareAlike</skos:altLabel>
         <skos:altLabel xml:lang="nb">Navngivelse-DelPåSammeVilkår</skos:altLabel>
         <skos:exactMatch rdf:resource="http://spdx.org/licenses/CC-BY-SA-4.0"/>
-        <skos:exactMatch rdf:resource="https://creativecommons.org/licenses/by-sa/4.0/rdf"/>
         <skos:exactMatch rdf:resource="https://creativecommons.org/licenses/by-sa/4.0/"/>
         <skos:definition xml:lang="en">This license lets others remix, adapt, and build upon your work even for commercial purposes, as long as they credit you and license their new creations under the identical terms. This license is often compared to “copyleft” free and open source software licenses. All new works based on yours will carry the same license, so any derivatives will also allow commercial use. This is the license used by Wikipedia, and is recommended for materials that would benefit from incorporating content from Wikipedia and similarly licensed projects.</skos:definition>
       </skos:Concept>
@@ -212,10 +212,10 @@
       <skos:Concept rdf:about="https://vocab.met.no/mmd/Use_Constraint/CC-BY-NC-4.0">
         <skos:prefLabel xml:lang="en">CC-BY-NC-4.0</skos:prefLabel>
         <skos:altLabel xml:lang="en">Creative Commons Attribution Non Commercial 4.0 International</skos:altLabel>
+        <skos:altLabel xml:lang="en">CC BY-NC 4.0</skos:altLabel>
         <skos:altLabel xml:lang="en">Attribution-NonCommercial</skos:altLabel>
         <skos:altLabel xml:lang="nb">Navngivelse-IkkeKommersiell</skos:altLabel>
         <skos:exactMatch rdf:resource="http://spdx.org/licenses/CC-BY-NC-4.0"/>
-        <skos:exactMatch rdf:resource="https://creativecommons.org/licenses/by-nc/4.0/rdf"/>
         <skos:exactMatch rdf:resource="https://creativecommons.org/licenses/by-nc/4.0/"/>
         <skos:definition xml:lang="en">This license lets others remix, adapt, and build upon your work non-commercially, and although their new works must also acknowledge you and be non-commercial, they don’t have to license their derivative works on the same terms.</skos:definition>
       </skos:Concept>
@@ -225,10 +225,10 @@
       <skos:Concept rdf:about="https://vocab.met.no/mmd/Use_Constraint/CC-BY-NC-SA-4.0">
         <skos:prefLabel xml:lang="en">CC-BY-NC-SA-4.0</skos:prefLabel>
         <skos:altLabel xml:lang="en">Creative Commons Attribution Non Commercial Share Alike 4.0 International</skos:altLabel>
+        <skos:altLabel xml:lang="en">CC BY-NC-SA 4.0</skos:altLabel>
         <skos:altLabel xml:lang="en">Attribution-NonCommercial-ShareAlike</skos:altLabel>
         <skos:altLabel xml:lang="nb">Navngivelse-IkkeKommersiell-DelPåSammeVilkår</skos:altLabel>
         <skos:exactMatch rdf:resource="http://spdx.org/licenses/CC-BY-NC-SA-4.0"/>
-        <skos:exactMatch rdf:resource="https://creativecommons.org/licenses/by-nc-sa/4.0/rdf"/>
         <skos:exactMatch rdf:resource="https://creativecommons.org/licenses/by-nc-sa/4.0/"/>
         <skos:definition xml:lang="en">This license lets others remix, adapt, and build upon your work non-commercially, as long as they credit you and license their new creations under the identical terms.</skos:definition>
       </skos:Concept>
@@ -238,10 +238,10 @@
       <skos:Concept rdf:about="https://vocab.met.no/mmd/Use_Constraint/CC-BY-ND-4.0">
         <skos:prefLabel xml:lang="en">CC-BY-ND-4.0</skos:prefLabel>
         <skos:altLabel xml:lang="en">Creative Commons Attribution No Derivatives 4.0 International</skos:altLabel>
+        <skos:altLabel xml:lang="en">CC BY-ND 4.0</skos:altLabel>
         <skos:altLabel xml:lang="en">Attribution-NoDerivs</skos:altLabel>
         <skos:altLabel xml:lang="nb">Navngivelse-IngenBearbeidelse</skos:altLabel>
         <skos:exactMatch rdf:resource="http://spdx.org/licenses/CC-BY-ND-4.0"/>
-        <skos:exactMatch rdf:resource="https://creativecommons.org/licenses/by-nd/4.0/rdf"/>
         <skos:exactMatch rdf:resource="https://creativecommons.org/licenses/by-nd/4.0/"/>
         <skos:definition xml:lang="en">This license lets others reuse the work for any purpose, including commercially; however, it cannot be shared with others in adapted form, and credit must be provided to you.</skos:definition>
       </skos:Concept>
@@ -251,10 +251,10 @@
       <skos:Concept rdf:about="https://vocab.met.no/mmd/Use_Constraint/CC-BY-NC-ND-4.0">
         <skos:prefLabel xml:lang="en">CC-BY-NC-ND-4.0</skos:prefLabel>
         <skos:altLabel xml:lang="en">Creative Commons Attribution Non Commercial No Derivatives 4.0 International</skos:altLabel>
+        <skos:altLabel xml:lang="en">CC BY-NC-ND 4.0</skos:altLabel>
         <skos:altLabel xml:lang="en">Attribution-NonCommercial-NoDerivs</skos:altLabel>
         <skos:altLabel xml:lang="nb">Navngivelse-IkkeKommersiell-IngenBearbeidelser</skos:altLabel>
-        <skos:exactMatch rdf:resource="http://spdx.org/licenses/CC-BY-NC-ND4.0"/>
-        <skos:exactMatch rdf:resource="https://creativecommons.org/licenses/by-nc-nd/4.0/rdf"/>
+        <skos:exactMatch rdf:resource="http://spdx.org/licenses/CC-BY-NC-ND-4.0"/>
         <skos:exactMatch rdf:resource="https://creativecommons.org/licenses/by-nc-nd/4.0/"/>
         <skos:definition xml:lang="en">This license is the most restrictive of our six main licenses, only allowing others to download your works and share them with others as long as they credit you, but they can’t change them in any way or use them commercially.</skos:definition>
       </skos:Concept>

--- a/xslt/dif-to-mmd.xsl
+++ b/xslt/dif-to-mmd.xsl
@@ -20,6 +20,8 @@ Added more support for DIF 10 Øystein Godøy, METNO/FOU, 2023-04-24
     <xsl:key name="isoc" match="skos:Collection[@rdf:about='https://vocab.met.no/mmd/ISO_Topic_Category']/skos:member/skos:Concept" use="skos:altLabel"/>
     <xsl:variable name="isoLUD" select="document('../thesauri/mmd-vocabulary.xml')"/>
     <xsl:key name="accessc" match="skos:Collection[@rdf:about='https://vocab.met.no/mmd/Access_Constraint']/skos:member/skos:Concept/skos:altLabel" use="translate(.,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz')"/>
+    <xsl:key name="usec" match="skos:Collection[@rdf:about='https://vocab.met.no/mmd/Use_Constraint']/skos:member/skos:Concept" use="skos:prefLabel"/>
+    <xsl:key name="useca" match="skos:Collection[@rdf:about='https://vocab.met.no/mmd/Use_Constraint']/skos:member/skos:Concept" use="skos:altLabel"/>
     <!--
     <xsl:key name="isoc" match="Concept" use="altLabel"/>
 -->
@@ -94,6 +96,7 @@ Added more support for DIF 10 Øystein Godøy, METNO/FOU, 2023-04-24
             <xsl:apply-templates select="dif:Project" />
             <xsl:apply-templates select="dif:Spatial_Coverage" />
             <xsl:apply-templates select="dif:Access_Constraints" />
+            <xsl:apply-templates select="dif:Use_Constraints" />
 	    <xsl:apply-templates select="dif:Data_Set_Language|dif:Dataset_Language"/>
             <xsl:apply-templates select="dif:Related_URL" />
             <xsl:apply-templates select="dif:Personnel" />
@@ -457,6 +460,47 @@ Added more support for DIF 10 Øystein Godøy, METNO/FOU, 2023-04-24
                     </xsl:element>
 		</xsl:if>
 	    </xsl:for-each>
+        </xsl:template>
+
+        <xsl:template match="dif:Use_Constraints">
+            <xsl:variable name="difuse" select="."/>
+	    <xsl:if test="not(normalize-space($difuse)='')">
+	        <xsl:for-each select="$isoLUD" >
+	            <xsl:choose>
+                        <xsl:when test="key('usec', $difuse)">
+                            <xsl:variable name="prefuseid" select="key('usec', $difuse)/skos:prefLabel"/>
+                            <xsl:variable name="prefuseref" select="key('usec', $difuse)/skos:exactMatch/@rdf:resource[contains(.,'spdx')]"/>
+                            <xsl:element name="mmd:use_constraint">
+                                <xsl:element name="mmd:identifier">
+                                    <xsl:value-of select="$prefuseid" />
+                                </xsl:element>
+                                <xsl:element name="mmd:resource">
+                                    <xsl:value-of select="$prefuseref" />
+                                </xsl:element>
+                            </xsl:element>
+                        </xsl:when>
+                        <xsl:when test="key('useca', $difuse)">
+                            <xsl:variable name="prefuseid" select="key('useca', $difuse)/skos:prefLabel"/>
+                            <xsl:variable name="prefuseref" select="key('useca', $difuse)/skos:exactMatch/@rdf:resource[contains(.,'spdx')]"/>
+                            <xsl:element name="mmd:use_constraint">
+                                <xsl:element name="mmd:identifier">
+                                    <xsl:value-of select="$prefuseid" />
+                                </xsl:element>
+                                <xsl:element name="mmd:resource">
+                                    <xsl:value-of select="$prefuseref" />
+                                </xsl:element>
+                            </xsl:element>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <xsl:element name="mmd:use_constraint">
+                                <xsl:element name="mmd:license_text">
+                                    <xsl:value-of select="$difuse" />
+                                </xsl:element>
+                            </xsl:element>
+	                </xsl:otherwise>
+	            </xsl:choose>
+	        </xsl:for-each>
+            </xsl:if>
         </xsl:template>
 
         <xsl:template match="dif:Data_Set_Language|dif:Dataset_Language">


### PR DESCRIPTION
1. I've reviewed the license vocabulary, adding altLabel to support translations from external resources. 
2. Updated CC0 which had a faulty reference
3. Included Use_Constraint to dif-to-mmd (this now checks for prefLabel, e.g. CC-BY-4.0, but also for altLabel, e.g. CC BY 4.0, and creates the appropriate identifier/resources in mmd). Any other non empty case will be put into license_text. 

This closes #246 and #247 

Note: more altLabel can be added in the future if harvested records provide some other consistent strings. 