### PR TITLE
add test on thesauri files

### DIFF
--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -99,3 +99,14 @@ class TestXSLTs(unittest.TestCase):
         dcatap = ET.tostring(newdom, xml_declaration = True, encoding='UTF-8', pretty_print=True)
         self.assertIsInstance(rdflib.Graph().parse(data=dcatap, format="xml"), rdflib.graph.Graph)
     
+class TestVOCAB(unittest.TestCase):
+
+    def test_mmd_vocab_ttl(self):
+        inputpath = os.path.join(pathlib.Path.cwd(), 'thesauri', 'mmd-vocabulary.ttl')
+        graph = rdflib.Graph()
+        self.assertIsInstance(graph.parse(inputpath, format="turtle"), rdflib.graph.Graph)
+
+    def test_mmd_vocab_xml(self):
+        inputpath = os.path.join(pathlib.Path.cwd(), 'thesauri', 'mmd-vocabulary.xml')
+        graph = rdflib.Graph()
+        self.assertIsInstance(graph.parse(inputpath, format="xml"), rdflib.graph.Graph)


### PR DESCRIPTION
These two tests should ensure that the xml and ttl files in the thesauri folder are not faulty. Closes #255 