### PR TITLE
add Data server landing page as related information type

### DIFF
--- a/doc/ch04-md-contrvocabs.adoc
+++ b/doc/ch04-md-contrvocabs.adoc
@@ -662,6 +662,7 @@ information page containing more detailed information on the observation
 facility following OGC Observations and Measurements or WMO Integrated
 Global Observing System approach.
 |Extended metadata |Additional unspecified metadata on the data. 
+|Data server landing page|The URL to access an application server (e.g. THREDDS, Hyrax and ERDDAP) landing page or catalog.
 |====================================================================
 
 <<related_information>>
@@ -674,8 +675,7 @@ Global Observing System approach.
 |Code |Description
 
 |HTTP |Direct access to the full data file. May require authentication,
-but should point directly to the data file or a catalogue containing the
-data.
+but should point directly to the data file.
 
 |OPeNDAP |Open-source Project for a Network Data Access Protocol
 

--- a/thesauri/mmd-vocabulary.ttl
+++ b/thesauri/mmd-vocabulary.ttl
@@ -447,8 +447,9 @@
   a skos:Collection, isothes:ConceptGroup ;
   skos:inScheme <https://vocab.met.no/mmd>;
   skos:prefLabel "Related Information Types"@en ;
+  skos:changeNote "2025-02-28, Added Data server landing page in collection"@en ;
   skos:definition "Description of the type of related information provided."@en ;
-  skos:member <https://vocab.met.no/mmd/Related_Information_Types/ProjectHomePage>, <https://vocab.met.no/mmd/Related_Information_Types/UsersGuide>, <https://vocab.met.no/mmd/Related_Information_Types/DatasetLandingPage>, <https://vocab.met.no/mmd/Related_Information_Types/ScientificPublication>, <https://vocab.met.no/mmd/Related_Information_Types/DataPaper>, <https://vocab.met.no/mmd/Related_Information_Types/DataManagementPlan>, <https://vocab.met.no/mmd/Related_Information_Types/Software>, <https://vocab.met.no/mmd/Related_Information_Types/OtherDocumentation>, <https://vocab.met.no/mmd/Related_Information_Types/ObservationFacility>, <https://vocab.met.no/mmd/Related_Information_Types/ExtendedMetadata> .
+  skos:member <https://vocab.met.no/mmd/Related_Information_Types/ProjectHomePage>, <https://vocab.met.no/mmd/Related_Information_Types/UsersGuide>, <https://vocab.met.no/mmd/Related_Information_Types/DatasetLandingPage>, <https://vocab.met.no/mmd/Related_Information_Types/ScientificPublication>, <https://vocab.met.no/mmd/Related_Information_Types/DataPaper>, <https://vocab.met.no/mmd/Related_Information_Types/DataManagementPlan>, <https://vocab.met.no/mmd/Related_Information_Types/Software>, <https://vocab.met.no/mmd/Related_Information_Types/OtherDocumentation>, <https://vocab.met.no/mmd/Related_Information_Types/ObservationFacility>, <https://vocab.met.no/mmd/Related_Information_Types/ExtendedMetadata>, <https://vocab.met.no/mmd/Related_Information_Types/DataServerLandingPage> .
 
 <https://vocab.met.no/mmd/Related_Information_Types/ProjectHomePage>
   a skos:Concept ;
@@ -471,13 +472,13 @@
 <https://vocab.met.no/mmd/Related_Information_Types/ScientificPublication>
   a skos:Concept ;
   skos:prefLabel "Scientific publication"@en ;
-  skos:broader <https://gcmd.earthdata.nasa.gov/kms/concept/13a4deec-bd22-4864-9804-77fac181f484> ;
+  skos:broadMatch <https://gcmd.earthdata.nasa.gov/kms/concept/13a4deec-bd22-4864-9804-77fac181f484> ;
   skos:definition "A scientific publication."@en .
 
 <https://vocab.met.no/mmd/Related_Information_Types/DataPaper>
   a skos:Concept ;
   skos:prefLabel "Data paper"@en ;
-  skos:broader <https://gcmd.earthdata.nasa.gov/kms/concept/13a4deec-bd22-4864-9804-77fac181f484> ;
+  skos:broadMatch <https://gcmd.earthdata.nasa.gov/kms/concept/13a4deec-bd22-4864-9804-77fac181f484> ;
   skos:definition "A factual and objective publication with a focused intent to identify and describe specific data, sets of data, or data collections to facilitate discoverability."@en .
 
 <https://vocab.met.no/mmd/Related_Information_Types/DataManagementPlan>
@@ -507,6 +508,12 @@
   skos:exactMatch <https://gcmd.earthdata.nasa.gov/kms/concept/3c9d4493-22fd-48a8-9af5-bf0d16b7ede5> ;
   skos:definition "Additional unspecified metadata on the data."@en .
 
+<https://vocab.met.no/mmd/Related_Information_Types/DataServerLandingPage>
+  a skos:Concept ;
+  skos:prefLabel "Data server landing page"@en ;
+  skos:narrowMatch <https://gcmd.earthdata.nasa.gov/kms/concept/77cae7cb-4676-4c69-a88b-d78971496f97> ;
+  skos:definition "The URL to access an application server (e.g. THREDDS, Hyrax and ERDDAP) landing page or catalog."@en .
+
 <https://vocab.met.no/mmd/Data_Access_Types>
   a skos:Collection, isothes:ConceptGroup ;
   skos:inScheme <https://vocab.met.no/mmd>;
@@ -518,7 +525,7 @@
   a skos:Concept ;
   skos:prefLabel "HTTP"@en ;
   skos:broader <https://gcmd.earthdata.nasa.gov/kms/concept/8e33a2dd-df13-4079-8636-391abb5344c6> ;
-  skos:definition "Direct access to the full data file. May require authentication, but should point directly to the data file or a catalogue containing the data."@en .
+  skos:definition "Direct access to the full data file. May require authentication, but should point directly to the data file."@en .
 
 <https://vocab.met.no/mmd/Data_Access_Types/OPeNDAP>
   a skos:Concept ;

--- a/thesauri/mmd-vocabulary.xml
+++ b/thesauri/mmd-vocabulary.xml
@@ -601,6 +601,7 @@
     <rdf:type rdf:resource="http://purl.org/iso25964/skos-thes#ConceptGroup"/>
     <skos:inScheme rdf:resource="https://vocab.met.no/mmd"/>
     <skos:prefLabel xml:lang="en">Related Information Types</skos:prefLabel>
+    <skos:changeNote xml:lang="en">2025-02-28, Added Data server landing page in collection</skos:changeNote>
     <skos:definition xml:lang="en">Description of the type of related information provided.</skos:definition>
     <skos:member>
       <skos:Concept rdf:about="https://vocab.met.no/mmd/Related_Information_Types/ProjectHomePage">
@@ -629,7 +630,7 @@
     <skos:member>
       <skos:Concept rdf:about="https://vocab.met.no/mmd/Related_Information_Types/ScientificPublication">
         <skos:prefLabel xml:lang="en">Scientific publication</skos:prefLabel>
-        <skos:broader rdf:resource="https://gcmd.earthdata.nasa.gov/kms/concept/13a4deec-bd22-4864-9804-77fac181f484"/>
+        <skos:broadMatch rdf:resource="https://gcmd.earthdata.nasa.gov/kms/concept/13a4deec-bd22-4864-9804-77fac181f484"/>
         <skos:definition xml:lang="en">A scientific publication.</skos:definition>
       </skos:Concept>
     </skos:member>
@@ -637,7 +638,7 @@
     <skos:member>
       <skos:Concept rdf:about="https://vocab.met.no/mmd/Related_Information_Types/DataPaper">
         <skos:prefLabel xml:lang="en">Data paper</skos:prefLabel>
-        <skos:broader rdf:resource="https://gcmd.earthdata.nasa.gov/kms/concept/13a4deec-bd22-4864-9804-77fac181f484"/>
+        <skos:broadMatch rdf:resource="https://gcmd.earthdata.nasa.gov/kms/concept/13a4deec-bd22-4864-9804-77fac181f484"/>
         <skos:definition xml:lang="en">A factual and objective publication with a focused intent to identify and describe specific data, sets of data, or data collections to facilitate discoverability.</skos:definition>
       </skos:Concept>
     </skos:member>
@@ -679,6 +680,14 @@
       </skos:Concept>
     </skos:member>
 
+    <skos:member>
+      <skos:Concept rdf:about="https://vocab.met.no/mmd/Related_Information_Types/DataServerLandingPage">
+        <skos:prefLabel xml:lang="en">Data server landing page</skos:prefLabel>
+        <skos:narrowMatch rdf:resource="https://gcmd.earthdata.nasa.gov/kms/concept/77cae7cb-4676-4c69-a88b-d78971496f97"/>
+        <skos:definition xml:lang="en">The URL to access an application server (e.g. THREDDS, Hyrax and ERDDAP) landing page or catalog.</skos:definition>
+      </skos:Concept>
+    </skos:member>
+
   </skos:Collection>
 
   <skos:Collection rdf:about="https://vocab.met.no/mmd/Data_Access_Types">
@@ -690,7 +699,7 @@
       <skos:Concept rdf:about="https://vocab.met.no/mmd/Data_Access_Types/HTTP">
         <skos:prefLabel xml:lang="en">HTTP</skos:prefLabel>
         <skos:broader rdf:resource="https://gcmd.earthdata.nasa.gov/kms/concept/8e33a2dd-df13-4079-8636-391abb5344c6"/>
-        <skos:definition xml:lang="en">Direct access to the full data file. May require authentication, but should point directly to the data file or a catalogue containing the data.</skos:definition>
+        <skos:definition xml:lang="en">Direct access to the full data file. May require authentication, but should point directly to the data file.</skos:definition>
       </skos:Concept>
     </skos:member>
 

--- a/xsd/mmd.xsd
+++ b/xsd/mmd.xsd
@@ -447,6 +447,7 @@
             <xs:enumeration value="Other documentation"></xs:enumeration>
             <xs:enumeration value="Observation facility"></xs:enumeration>
             <xs:enumeration value="Extended metadata"></xs:enumeration>
+            <xs:enumeration value="Data server landing page"></xs:enumeration>
         </xs:restriction>
     </xs:simpleType>
 

--- a/xsd/mmd_strict.xsd
+++ b/xsd/mmd_strict.xsd
@@ -471,6 +471,7 @@
             <xs:enumeration value="Other documentation"></xs:enumeration>
             <xs:enumeration value="Observation facility"></xs:enumeration>
             <xs:enumeration value="Extended metadata"></xs:enumeration>
+            <xs:enumeration value="Data server landing page"></xs:enumeration>
         </xs:restriction>
     </xs:simpleType>
 

--- a/xslt/mmd-to-dif.xsl
+++ b/xslt/mmd-to-dif.xsl
@@ -588,6 +588,24 @@
                         </xsl:element>
                     </xsl:element>
 	        </xsl:if>
+        <xsl:if test="mmd:type = 'Data server landing page' and contains(mmd:resource,'thredds')">
+            <xsl:element name="dif:Related_URL">
+                <xsl:element name="dif:URL_Content_Type">
+                    <xsl:element name="dif:Type">
+                        <xsl:text>GET DATA</xsl:text>
+                    </xsl:element>
+                    <xsl:element name="dif:Subtype">
+                        <xsl:text>THREDDS DATA</xsl:text>
+                    </xsl:element>
+                </xsl:element>
+                <xsl:element name="dif:URL">
+                    <xsl:value-of select="mmd:resource"/>
+                </xsl:element>
+                <xsl:element name="dif:Description">
+                    <xsl:value-of select="mmd:description"/>
+                </xsl:element>
+            </xsl:element>
+        </xsl:if>
 		<xsl:if test="mmd:type = 'Project home page'">
                     <xsl:element name="dif:Related_URL">
                         <xsl:element name="dif:URL_Content_Type">

--- a/xslt/mmd-to-dif10.xsl
+++ b/xslt/mmd-to-dif10.xsl
@@ -119,6 +119,24 @@
                         </xsl:element>
                     </xsl:element>
 	        </xsl:if>
+        <xsl:if test="mmd:type = 'Data server landing page' and contains(mmd:resource,'thredds')">
+            <xsl:element name="dif:Related_URL">
+                <xsl:element name="dif:URL_Content_Type">
+                    <xsl:element name="dif:Type">
+                        <xsl:text>USE SERVICE API</xsl:text>
+                    </xsl:element>
+                    <xsl:element name="dif:Subtype">
+                        <xsl:text>THREDDS DATA</xsl:text>
+                    </xsl:element>
+                </xsl:element>
+                <xsl:element name="dif:URL">
+                    <xsl:value-of select="mmd:resource"/>
+                </xsl:element>
+                <xsl:element name="dif:Description">
+                    <xsl:value-of select="mmd:description"/>
+                </xsl:element>
+            </xsl:element>
+        </xsl:if>
 		<xsl:if test="mmd:type = 'Project home page'">
                     <xsl:element name="dif:Related_URL">
                         <xsl:element name="dif:URL_Content_Type">


### PR DESCRIPTION
This PR closes #207 
The purpose is to find a place to keep the urls from application servers (e.g. thredds) while moving these resources from the type "dataset landing page". This new element will host application server urls from data files and virtual data collection (e.g. catalogs). 

- it introduces a new type in the vocabulary
- it updates documentation
- it updates xsd schemas
- it extends translation mmd-to-dif(10). 

In addition a small bug fix in the vocabulary is done for broader/broadMatch on Data Paper and Scientific Publication