### PR TITLE
change schemaLocation in xsd to local copy instead of remote file

### DIFF
--- a/xsd/mmd.xsd
+++ b/xsd/mmd.xsd
@@ -2,7 +2,7 @@
 <xs:schema elementFormDefault="qualified" targetNamespace="http://www.met.no/schema/mmd"
            xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xml="http://www.w3.org/XML/1998/namespace"
            xmlns:mmd="http://www.met.no/schema/mmd" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-    <xs:import schemaLocation="http://www.w3.org/2001/xml.xsd" namespace="http://www.w3.org/XML/1998/namespace"/>
+    <xs:import schemaLocation="xml.xsd" namespace="http://www.w3.org/XML/1998/namespace"/>
     <xs:element name="mmd" type="mmd:mmd_type"></xs:element>
     <xs:complexType name="personnel_type">
         <xs:all>

--- a/xsd/mmd_strict.xsd
+++ b/xsd/mmd_strict.xsd
@@ -2,7 +2,7 @@
 <xs:schema elementFormDefault="qualified" targetNamespace="http://www.met.no/schema/mmd"
            xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xml="http://www.w3.org/XML/1998/namespace"
            xmlns:mmd="http://www.met.no/schema/mmd" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-    <xs:import schemaLocation="http://www.w3.org/2001/xml.xsd" namespace="http://www.w3.org/XML/1998/namespace"/>
+    <xs:import schemaLocation="xml.xsd" namespace="http://www.w3.org/XML/1998/namespace"/>
     <xs:element name="mmd" type="mmd:mmd_type"></xs:element>
     <xs:complexType name="personnel_type">
         <xs:all>


### PR DESCRIPTION
Changing schemaLocation in xsd to use a local copy of xml.xsd will not rely on availability of external resources. This closes #290 