### PR TITLE
modification of workflow: adding enumeration generation

### DIFF
--- a/.github/workflows/make-doc.yml
+++ b/.github/workflows/make-doc.yml
@@ -1,12 +1,15 @@
-
-name: 'html/pdf'
+name: 'enumeration and doc'
 
 on:
   push:
     branches:
       - master
+
     paths:
+      - 'thesauri/mmd-vocabulary.ttl'
       - 'doc/**'
+      - 'xsd/create_enum.py'
+      - 'xsd/enum_mmd.xsd'
 
 jobs:
   build:
@@ -14,7 +17,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v5
+
+    - name: enumeration
+      run: |
+        docker compose -f docker-compose.enumeration.yml up
 
     - name: create html and pdf
       run: |
@@ -24,12 +31,13 @@ jobs:
       run: |
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
+        git add -f xsd/enum_mmd.xsd
+        git add -f doc/ch04-md-contrvocabs.adoc
         git add -f doc/mmd-specification.html
         git add -f doc/mmd-specification.pdf
-        git commit -m "Automatic updated by GitHub Action"
+        git commit -m "Automatic updated by GitHub Action: generate enum and html/pdf"
 
     - name: push code to ${{ github.ref }}
       run: |
         remote_repo="https://${GITHUB_ACTOR}:${{ secrets.GITHUB_TOKEN }}@github.com/${GITHUB_REPOSITORY}.git"
         git push "${remote_repo}" HEAD:${{ github.ref }} --follow-tags
-

--- a/Dockerfile.asciidoctor
+++ b/Dockerfile.asciidoctor
@@ -4,7 +4,7 @@
 #
 
 FROM ruby:alpine
-LABEL maintainer="aheimsbakk@met.no"
+LABEL maintainer="laraf@met.no"
 
 RUN gem install asciidoctor; \
     gem install asciidoctor-pdf --pre; \

--- a/Dockerfile.enumeration
+++ b/Dockerfile.enumeration
@@ -1,0 +1,15 @@
+#
+# Docker file used in GitHub Actions run enumeration.
+#
+
+FROM python:3.8-slim
+LABEL maintainer="laraf@met.no"
+
+RUN apt-get update && \
+    apt-get install -y git && \
+    apt-get clean && \
+    pip install "rdflib" \
+                "lxml"
+
+VOLUME /src
+WORKDIR /src

--- a/docker-compose.enumeration.yml
+++ b/docker-compose.enumeration.yml
@@ -1,0 +1,16 @@
+version: '3.4'
+
+services:
+  enum:
+    build:
+      context: .
+      dockerfile: Dockerfile.enumeration
+    environment:
+      CI: "${CI}"
+      GITHUB_REF: "${GITHUB_REF}"
+      GITHUB_SHA: "${GITHUB_SHA}"
+      GITHUB_ACTIONS: "${GITHUB_ACTIONS}"
+    volumes:
+      - .:/src
+    command: sh -c "cd xsd && ./create_enum.py && cd .."
+


### PR DESCRIPTION
This PR refers to #333 

The idea is that the authoritative source of vocabularies is the mmd-vocabulary.ttl file.
This is read in the create_enum.py which is generating i)  enum_mmd.xsd included in mmd.xsd and ii) ch04-md-contrvocabs.adoc which is included in the documentation. 

When the ttl file is modified the script should run. Since ch04-md-contrvocabs.adoc is updated then the new html/pdf should be recreated with asciidoc and pushed. 

In addition we want to avoid anybody editing ch04-md-contrvocabs.adoc and  enum_mmd.xsd manually, so if they are modified the script should run to overwrite them and re-establish the proper vocabulary as in the ttl file. 

This can be probably improved, but we can settle for an easy version now. 

Closes #333 